### PR TITLE
Add InputFile(URL) constructor with URL->File cache

### DIFF
--- a/src/main/java/pro/zackpollard/telegrambot/api/chat/message/send/InputFile.java
+++ b/src/main/java/pro/zackpollard/telegrambot/api/chat/message/send/InputFile.java
@@ -1,9 +1,18 @@
 package pro.zackpollard.telegrambot.api.chat.message.send;
 
+import com.mashape.unirest.http.HttpResponse;
+import com.mashape.unirest.http.Unirest;
+import com.mashape.unirest.http.exceptions.UnirestException;
 import lombok.Getter;
 import pro.zackpollard.telegrambot.api.TelegramBot;
+import pro.zackpollard.telegrambot.api.internal.FileExtension;
+import pro.zackpollard.telegrambot.api.internal.managers.FileManager;
 
 import java.io.File;
+import java.io.IOException;
+import java.io.InputStream;
+import java.net.URL;
+import java.nio.file.Files;
 
 /**
  * @author Zack Pollard
@@ -14,6 +23,32 @@ public class InputFile {
 	private final String fileID;
 	@Getter
 	private final File file;
+
+	public InputFile(URL url) {
+
+		File file = TelegramBot.getFileManager().getFile(url);
+		if (file == null) {
+			try {
+				String stringifiedUrl = url.toExternalForm();
+				HttpResponse<InputStream> response = Unirest.get(stringifiedUrl).asBinary();
+				String extension = FileExtension.getByMimeType(response.getHeaders().getFirst("content-type"));
+				if (extension == null) {
+					extension = stringifiedUrl.substring(stringifiedUrl.lastIndexOf('.') + 1);
+					if (extension.length() > 4) {
+						extension = null; // Default to .tmp if there was no valid extension
+					}
+				}
+				file = File.createTempFile("jtb-"+System.currentTimeMillis(), extension, FileManager.getTemporaryFolder());
+				file.deleteOnExit();
+				TelegramBot.getFileManager().cacheUrl(url, file);
+				Files.copy(response.getRawBody(), file.toPath());
+			} catch (UnirestException | IOException ex) {
+				ex.printStackTrace();
+			}
+		}
+		this.file = file;
+		this.fileID = TelegramBot.getFileManager().getFileID(file);
+	}
 
 	public InputFile(File file) {
 

--- a/src/main/java/pro/zackpollard/telegrambot/api/internal/FileExtension.java
+++ b/src/main/java/pro/zackpollard/telegrambot/api/internal/FileExtension.java
@@ -1,0 +1,54 @@
+package pro.zackpollard.telegrambot.api.internal;
+
+import lombok.Getter;
+
+import java.util.*;
+
+public enum FileExtension {
+
+    // TODO: add more mime types?
+    UNKNOWN(""),
+    JPG("jpg", "image/jpeg"),
+    PNG("png", "image/png"),
+    GIF("gif", "image/gif"),
+    MP4("mp4", "video/mp4"),
+    MOV("mov", "video/quicktime"),
+    MP3("mp3", "audio/mp3"),
+    AVI("avi", "video/avi"),
+    MKV("mkv", "video/x-matroska");
+
+    @Getter
+    private final String extension;
+
+    @Getter
+    private final String[] mimeTypes;
+
+    private static final Map<String, FileExtension> byMimeType;
+
+    FileExtension(String extension, String...mimeTypes) {
+        this.extension = extension;
+        this.mimeTypes = mimeTypes;
+    }
+
+    static {
+        Map<String, FileExtension> map = new HashMap<>();
+        for (FileExtension ext : values()) {
+            for (String mimeType : ext.getMimeTypes()) {
+                map.put(mimeType, ext);
+            }
+        }
+        byMimeType = Collections.unmodifiableMap(map);
+    }
+
+    public static String getByMimeType(String mimeType) {
+        if (mimeType == null) {
+            return null;
+        }
+        // If I recall correctly, there's a + separator used by some mime types, to append extra metadata such as versions
+        int index = mimeType.indexOf('+');
+        if (index > 0) {
+            mimeType = mimeType.substring(0, index);
+        }
+        return Optional.of(FileExtension.byMimeType.get(mimeType)).map(FileExtension::getExtension).orElse(null);
+    }
+}

--- a/src/main/java/pro/zackpollard/telegrambot/api/internal/managers/FileManager.java
+++ b/src/main/java/pro/zackpollard/telegrambot/api/internal/managers/FileManager.java
@@ -1,10 +1,15 @@
 package pro.zackpollard.telegrambot.api.internal.managers;
 
+import org.apache.commons.io.FileUtils;
+
 import java.io.File;
 import java.io.FileInputStream;
 import java.io.IOException;
+import java.net.URISyntaxException;
+import java.net.URL;
 import java.security.MessageDigest;
 import java.security.NoSuchAlgorithmException;
+import java.util.Arrays;
 import java.util.HashMap;
 import java.util.Map;
 
@@ -14,11 +19,14 @@ import java.util.Map;
 public class FileManager {
 
 	private static MessageDigest md5Digest;
+	private static File tmpDirectory;
 	private final Map<String, String> checksumIDs;
+	private final Map<URL, File> urlCache;
 
 	public FileManager() {
 
 		this.checksumIDs = new HashMap<>();
+		this.urlCache = new HashMap<>();
 
 		if (md5Digest == null) {
 
@@ -92,5 +100,30 @@ public class FileManager {
 		}
 
 		return checksum;
+	}
+
+	public File getFile(URL url) {
+		return this.urlCache.get(url);
+	}
+
+	public void cacheUrl(URL url, File file) {
+		this.urlCache.put(url, file);
+	}
+
+	public static File getTemporaryFolder() {
+		return tmpDirectory;
+	}
+
+	static {
+		try {
+			File jarDir = new File(FileManager.class.getProtectionDomain().getCodeSource().getLocation().toURI().getPath());
+			tmpDirectory = new File(jarDir, "tmp");
+			// In case the JVM is not nice enough to delete our files
+			File[] contents = tmpDirectory.listFiles();
+			if (contents != null) {
+				Arrays.stream(contents).forEach(FileUtils::deleteQuietly);
+			}
+		} catch (URISyntaxException ignored) {
+		}
 	}
 }


### PR DESCRIPTION
This commit adds:
- A InputFile(java.net.URL) constructor which automagically fetches the file.
- A URL -> File cache based on URL which expires once your application exits (JVM should handle file cleanup).
- A small FileExtension enum to map mime types to extensions.
