### PR TITLE
Fix encoding issue, fixes #38

### DIFF
--- a/src/main/java/pro/zackpollard/telegrambot/api/TelegramBot.java
+++ b/src/main/java/pro/zackpollard/telegrambot/api/TelegramBot.java
@@ -100,7 +100,7 @@ public final class TelegramBot {
         try {
 
             MultipartBody request = Unirest.post(getBotAPIUrl() + "getChat")
-                    .field("chat_id", chatID, "application/json");
+                    .field("chat_id", chatID, "application/json; charset=utf8;");
             HttpResponse<String> response = request.asString();
             JSONObject jsonResponse = Utils.processResponse(response);
 
@@ -136,8 +136,8 @@ public final class TelegramBot {
 
                 try {
                     MultipartBody request = Unirest.post(getBotAPIUrl() + "sendMessage")
-                            .field("chat_id", chat.getId(), "application/json")
-                            .field("text", textMessage.getMessage(), "application/json")
+                            .field("chat_id", chat.getId(), "application/json; charset=utf8;")
+                            .field("text", textMessage.getMessage(), "application/json; charset=utf8;")
                             .field("disable_web_page_preview", textMessage.isDisableWebPagePreview())
                             .field("parse_mode", textMessage.getParseMode() != null ? textMessage.getParseMode().getModeName() : ParseMode.NONE);
 
@@ -158,7 +158,7 @@ public final class TelegramBot {
 
                 try {
                     MultipartBody request = Unirest.post(getBotAPIUrl() + "forwardMessage")
-                            .field("chat_id", chat.getId(), "application/json")
+                            .field("chat_id", chat.getId(), "application/json; charset=utf8;")
                             .field("from_chat_id", forwardMessage.getChatID())
                             .field("message_id", forwardMessage.getMessageID());
 
@@ -178,11 +178,11 @@ public final class TelegramBot {
 
                 try {
                     MultipartBody request = Unirest.post(getBotAPIUrl() + "sendPhoto")
-                            .field("chat_id", chat.getId(), "application/json")
+                            .field("chat_id", chat.getId(), "application/json; charset=utf8;")
                             .field("photo", photoMessage.getPhoto().getFileID() != null ? photoMessage.getPhoto().getFileID() : new FileContainer(photoMessage.getPhoto()), photoMessage.getPhoto().getFileID() == null);
 
                     if (photoMessage.getCaption() != null)
-                        request.field("caption", photoMessage.getCaption(), "application/json");
+                        request.field("caption", photoMessage.getCaption(), "application/json; charset=utf8;");
 
                     Utils.processReplyContent(request, photoMessage);
                     Utils.processNotificationContent(request, photoMessage);
@@ -231,7 +231,7 @@ public final class TelegramBot {
 
                 try {
                     MultipartBody request = Unirest.post(getBotAPIUrl() + "sendAudio")
-                            .field("chat_id", chat.getId(), "application/json")
+                            .field("chat_id", chat.getId(), "application/json; charset=utf8;")
                             .field("audio", audioMessage.getAudio().getFileID() != null ? audioMessage.getAudio().getFileID() : new FileContainer(audioMessage.getAudio()), audioMessage.getAudio().getFileID() == null);
 
                     Utils.processReplyContent(request, audioMessage);
@@ -239,9 +239,9 @@ public final class TelegramBot {
 
                     if (audioMessage.getDuration() != 0) request.field("duration", audioMessage.getDuration());
                     if (audioMessage.getPerformer() != null)
-                        request.field("performer", audioMessage.getPerformer(), "application/json");
+                        request.field("performer", audioMessage.getPerformer(), "application/json; charset=utf8;");
                     if (audioMessage.getTitle() != null)
-                        request.field("title", audioMessage.getTitle(), "application/json");
+                        request.field("title", audioMessage.getTitle(), "application/json; charset=utf8;");
 
                     response = request.asString();
                     jsonResponse = Utils.processResponse(response);
@@ -281,11 +281,11 @@ public final class TelegramBot {
 
                 try {
                     MultipartBody request = Unirest.post(getBotAPIUrl() + "sendDocument")
-                            .field("chat_id", chat.getId(), "application/json")
+                            .field("chat_id", chat.getId(), "application/json; charset=utf8;")
                             .field("document", documentMessage.getDocument().getFileID() != null ? documentMessage.getDocument().getFileID() : new FileContainer(documentMessage.getDocument()), documentMessage.getDocument().getFileID() == null);
 
                     if (documentMessage.getCaption() != null)
-                        request.field("caption", documentMessage.getCaption(), "application/json");
+                        request.field("caption", documentMessage.getCaption(), "application/json; charset=utf8;");
 
                     Utils.processReplyContent(request, documentMessage);
                     Utils.processNotificationContent(request, documentMessage);
@@ -327,7 +327,7 @@ public final class TelegramBot {
 
                 try {
                     MultipartBody request = Unirest.post(getBotAPIUrl() + "sendSticker")
-                            .field("chat_id", chat.getId(), "application/json")
+                            .field("chat_id", chat.getId(), "application/json; charset=utf8;")
                             .field("sticker", stickerMessage.getSticker().getFileID() != null ? stickerMessage.getSticker().getFileID() : new FileContainer(stickerMessage.getSticker()), stickerMessage.getSticker().getFileID() == null);
 
                     Utils.processReplyContent(request, stickerMessage);
@@ -363,14 +363,14 @@ public final class TelegramBot {
 
                 try {
                     MultipartBody request = Unirest.post(getBotAPIUrl() + "sendVideo")
-                            .field("chat_id", chat.getId(), "application/json")
+                            .field("chat_id", chat.getId(), "application/json; charset=utf8;")
                             .field("video", videoMessage.getVideo().getFileID() != null ? videoMessage.getVideo().getFileID() : new FileContainer(videoMessage.getVideo()), videoMessage.getVideo().getFileID() == null);
 
                     if (videoMessage.getDuration() > 0) request.field("duration", videoMessage.getDuration());
                     if (videoMessage.getWidth() > 0) request.field("width", videoMessage.getWidth());
                     if (videoMessage.getHeight() > 0) request.field("height", videoMessage.getHeight());
                     if (videoMessage.getCaption() != null)
-                        request.field("caption", videoMessage.getCaption(), "application/json");
+                        request.field("caption", videoMessage.getCaption(), "application/json; charset=utf8;");
 
                     Utils.processReplyContent(request, videoMessage);
                     Utils.processNotificationContent(request, videoMessage);
@@ -404,7 +404,7 @@ public final class TelegramBot {
 
                 try {
                     MultipartBody request = Unirest.post(getBotAPIUrl() + "sendVoice")
-                            .field("chat_id", chat.getId(), "application/json")
+                            .field("chat_id", chat.getId(), "application/json; charset=utf8;")
                             .field("voice", voiceMessage.getVoice().getFileID() != null ? voiceMessage.getVoice().getFileID() : new FileContainer(voiceMessage.getVoice()), voiceMessage.getVoice().getFileID() == null);
 
                     if (voiceMessage.getDuration() > 0) request.field("duration", voiceMessage.getDuration());
@@ -442,7 +442,7 @@ public final class TelegramBot {
 
                 try {
                     MultipartBody request = Unirest.post(getBotAPIUrl() + "sendLocation")
-                            .field("chat_id", chat.getId(), "application/json")
+                            .field("chat_id", chat.getId(), "application/json; charset=utf8;")
                             .field("latitude", locationMessage.getLatitude())
                             .field("longitude", locationMessage.getLongitude());
 
@@ -463,7 +463,7 @@ public final class TelegramBot {
                 try {
 
                     MultipartBody request = Unirest.post(getBotAPIUrl() + "sendLocation")
-                            .field("chat_id", chat.getId(), "application/json")
+                            .field("chat_id", chat.getId(), "application/json; charset=utf8;")
                             .field("latitude", venueMessage.getLatitude())
                             .field("longitude", venueMessage.getLongitude())
                             .field("title", venueMessage.getTitle())
@@ -487,7 +487,7 @@ public final class TelegramBot {
 
                 try {
                     MultipartBody request = Unirest.post(getBotAPIUrl() + "sendChatAction")
-                            .field("chat_id", chat.getId(), "application/json")
+                            .field("chat_id", chat.getId(), "application/json; charset=utf8;")
                             .field("action", sendableChatAction.getChatAction().getName());
 
                     response = request.asString();
@@ -508,14 +508,14 @@ public final class TelegramBot {
 
         try {
             MultipartBody requests = Unirest.post(getBotAPIUrl() + "editMessageText")
-                    .field("text", text, "application/json")
+                    .field("text", text, "application/json; charset=utf8;")
                     .field("disable_web_page_preview", disableWebPagePreview);
 
-            if(chatId != null) requests.field("chat_id", chatId, "application/json");
+            if(chatId != null) requests.field("chat_id", chatId, "application/json; charset=utf8;");
             if(messageId != null) requests.field("message_id", messageId);
-            if(inlineMessageId != null) requests.field("inline_message_id", inlineMessageId, "application/json");
-            if(parseMode != null) requests.field("parse_mode", parseMode.getModeName(), "application/json");
-            if(inlineReplyMarkup != null) requests.field("reply_markup", GSON.toJson(inlineReplyMarkup, InlineKeyboardMarkup.class), "application/json");
+            if(inlineMessageId != null) requests.field("inline_message_id", inlineMessageId, "application/json; charset=utf8;");
+            if(parseMode != null) requests.field("parse_mode", parseMode.getModeName(), "application/json; charset=utf8;");
+            if(inlineReplyMarkup != null) requests.field("reply_markup", GSON.toJson(inlineReplyMarkup, InlineKeyboardMarkup.class), "application/json; charset=utf8;");
 
             response = requests.asString();
             jsonResponse = Utils.processResponse(response);
@@ -568,12 +568,12 @@ public final class TelegramBot {
 
         try {
             MultipartBody requests = Unirest.post(getBotAPIUrl() + "editMessageCaption")
-                    .field("caption", caption, "application/json");
+                    .field("caption", caption, "application/json; charset=utf8;");
 
-            if(chatId != null) requests.field("chat_id", chatId, "application/json");
+            if(chatId != null) requests.field("chat_id", chatId, "application/json; charset=utf8;");
             if(messageId != null) requests.field("message_id", messageId);
-            if(inlineMessageId != null) requests.field("inline_message_id", inlineMessageId, "application/json");
-            if(inlineReplyMarkup != null) requests.field("reply_markup", GSON.toJson(inlineReplyMarkup, InlineKeyboardMarkup.class), "application/json");
+            if(inlineMessageId != null) requests.field("inline_message_id", inlineMessageId, "application/json; charset=utf8;");
+            if(inlineReplyMarkup != null) requests.field("reply_markup", GSON.toJson(inlineReplyMarkup, InlineKeyboardMarkup.class), "application/json; charset=utf8;");
 
             response = requests.asString();
             jsonResponse = Utils.processResponse(response);
@@ -626,11 +626,11 @@ public final class TelegramBot {
 
         try {
             MultipartBody requests = Unirest.post(getBotAPIUrl() + "editMessageReplyMarkup")
-                    .field("reply_markup", GSON.toJson(inlineReplyMarkup, InlineKeyboardMarkup.class), "application/json");
+                    .field("reply_markup", GSON.toJson(inlineReplyMarkup, InlineKeyboardMarkup.class), "application/json; charset=utf8;");
 
-            if(chatId != null) requests.field("chat_id", chatId, "application/json");
+            if(chatId != null) requests.field("chat_id", chatId, "application/json; charset=utf8;");
             if(messageId != null) requests.field("message_id", messageId);
-            if(inlineMessageId != null) requests.field("inline_message_id", inlineMessageId, "application/json");
+            if(inlineMessageId != null) requests.field("inline_message_id", inlineMessageId, "application/json; charset=utf8;");
 
             response = requests.asString();
             jsonResponse = Utils.processResponse(response);
@@ -717,8 +717,8 @@ public final class TelegramBot {
 
             try {
                 MultipartBody requests = Unirest.post(getBotAPIUrl() + "answerCallbackQuery")
-                        .field("callback_query_id", callbackQueryId, "application/json")
-                        .field("text", text, "application/json")
+                        .field("callback_query_id", callbackQueryId, "application/json; charset=utf8;")
+                        .field("text", text, "application/json; charset=utf8;")
                         .field("show_alert", showAlert);
 
                 response = requests.asString();
@@ -743,7 +743,7 @@ public final class TelegramBot {
 
         try {
             MultipartBody request = Unirest.post(getBotAPIUrl() + "kickChatMember")
-                    .field("chat_id", chatId, "application/json")
+                    .field("chat_id", chatId, "application/json; charset=utf8;")
                     .field("user_id", userId);
 
             response = request.asString();
@@ -767,7 +767,7 @@ public final class TelegramBot {
 
         try {
             MultipartBody request = Unirest.post(getBotAPIUrl() + "unbanChatMember")
-                    .field("chat_id", chatId, "application/json")
+                    .field("chat_id", chatId, "application/json; charset=utf8;")
                     .field("user_id", userId);
 
             response = request.asString();

--- a/src/main/java/pro/zackpollard/telegrambot/api/chat/Chat.java
+++ b/src/main/java/pro/zackpollard/telegrambot/api/chat/Chat.java
@@ -45,7 +45,7 @@ public interface Chat {
         try {
 
             MultipartBody request = Unirest.post(getBotInstance().getBotAPIUrl() + "getChatMembersCount")
-                    .field("chat_id", getId(), "application/json");
+                    .field("chat_id", getId(), "application/json; charset=utf8;");
             HttpResponse<String> response = request.asString();
             JSONObject jsonResponse = processResponse(response);
 
@@ -65,7 +65,7 @@ public interface Chat {
         try {
 
             MultipartBody request = Unirest.post(getBotInstance().getBotAPIUrl() + "getChatAdministrators")
-                    .field("chat_id", getId(), "application/json");
+                    .field("chat_id", getId(), "application/json; charset=utf8;");
             HttpResponse<String> response = request.asString();
             JSONObject jsonResponse = processResponse(response);
 
@@ -101,7 +101,7 @@ public interface Chat {
         try {
 
             MultipartBody request = Unirest.post(getBotInstance().getBotAPIUrl() + "getChatMember")
-                    .field("chat_id", getId(), "application/json")
+                    .field("chat_id", getId(), "application/json; charset=utf8;")
                     .field("user_id", userID);
             HttpResponse<String> response = request.asString();
             JSONObject jsonResponse = processResponse(response);
@@ -122,7 +122,7 @@ public interface Chat {
         try {
 
             MultipartBody request = Unirest.post(getBotInstance().getBotAPIUrl() + "leaveChat")
-                    .field("chat_id", getId(), "application/json");
+                    .field("chat_id", getId(), "application/json; charset=utf8;");
             HttpResponse<String> response = request.asString();
             JSONObject jsonResponse = processResponse(response);
 

--- a/src/main/java/pro/zackpollard/telegrambot/api/chat/message/content/type/File.java
+++ b/src/main/java/pro/zackpollard/telegrambot/api/chat/message/content/type/File.java
@@ -34,7 +34,7 @@ public interface File {
 
         try {
             jsonObject = Unirest.post(telegramBot.getBotAPIUrl() + "getFile")
-                    .field("file_id", getFileId(), "application/json")
+                    .field("file_id", getFileId(), "application/json; charset=utf8;")
                     .asJson().getBody().getObject();
         } catch (UnirestException e) {
             e.printStackTrace();

--- a/src/main/java/pro/zackpollard/telegrambot/api/internal/updates/RequestUpdatesManager.java
+++ b/src/main/java/pro/zackpollard/telegrambot/api/internal/updates/RequestUpdatesManager.java
@@ -63,7 +63,7 @@ public class RequestUpdatesManager extends UpdateManager {
 
                 try {
                     response = Unirest.post(requestUpdatesManager.getBotInstance().getBotAPIUrl() + "getUpdates")
-                            .field("offset", offset + 1, "application/json")
+                            .field("offset", offset + 1, "application/json; charset=utf8;")
                             .field("timeout", 10).asString();
                 } catch (UnirestException e) {
                     System.err.println("There was a connection error when trying to retrieve updates, waiting for 1 second and then trying again.");

--- a/src/main/java/pro/zackpollard/telegrambot/api/utils/Utils.java
+++ b/src/main/java/pro/zackpollard/telegrambot/api/utils/Utils.java
@@ -71,22 +71,22 @@ public class Utils {
     public static void processReplyContent(MultipartBody multipartBody, ReplyingOptions replyingOptions) {
 
         if (replyingOptions.getReplyTo() != 0)
-            multipartBody.field("reply_to_message_id", String.valueOf(replyingOptions.getReplyTo()), "application/json");
+            multipartBody.field("reply_to_message_id", String.valueOf(replyingOptions.getReplyTo()), "application/json; charset=utf8;");
         if (replyingOptions.getReplyMarkup() != null) {
 
             switch (replyingOptions.getReplyMarkup().getType()) {
 
                 case FORCE_REPLY:
-                    multipartBody.field("reply_markup", TelegramBot.GSON.toJson(replyingOptions.getReplyMarkup(), ForceReply.class), "application/json");
+                    multipartBody.field("reply_markup", TelegramBot.GSON.toJson(replyingOptions.getReplyMarkup(), ForceReply.class), "application/json; charset=utf8;");
                     break;
                 case KEYBOARD_HIDE:
-                    multipartBody.field("reply_markup", TelegramBot.GSON.toJson(replyingOptions.getReplyMarkup(), ReplyKeyboardHide.class), "application/json");
+                    multipartBody.field("reply_markup", TelegramBot.GSON.toJson(replyingOptions.getReplyMarkup(), ReplyKeyboardHide.class), "application/json; charset=utf8;");
                     break;
                 case KEYBOARD_MARKUP:
-                    multipartBody.field("reply_markup", TelegramBot.GSON.toJson(replyingOptions.getReplyMarkup(), ReplyKeyboardMarkup.class), "application/json");
+                    multipartBody.field("reply_markup", TelegramBot.GSON.toJson(replyingOptions.getReplyMarkup(), ReplyKeyboardMarkup.class), "application/json; charset=utf8;");
                     break;
                 case INLINE_KEYBOARD_MARKUP:
-                    multipartBody.field("reply_markup", TelegramBot.GSON.toJson(replyingOptions.getReplyMarkup(), InlineKeyboardMarkup.class), "application/json");
+                    multipartBody.field("reply_markup", TelegramBot.GSON.toJson(replyingOptions.getReplyMarkup(), InlineKeyboardMarkup.class), "application/json; charset=utf8;");
                     break;
             }
         }


### PR DESCRIPTION
This fixes issue with caption encoding for Photo / Video (#38);
Also this fixes all possible cases with encoding for ReplyMarkup, Inline.., etc;
