### PR TITLE
Conversation API

### DIFF
--- a/src/main/java/pro/zackpollard/telegrambot/api/TelegramBot.java
+++ b/src/main/java/pro/zackpollard/telegrambot/api/TelegramBot.java
@@ -19,10 +19,12 @@ import pro.zackpollard.telegrambot.api.chat.message.content.type.Sticker;
 import pro.zackpollard.telegrambot.api.chat.message.content.type.Video;
 import pro.zackpollard.telegrambot.api.chat.message.content.type.Voice;
 import pro.zackpollard.telegrambot.api.chat.message.send.*;
+import pro.zackpollard.telegrambot.api.conversations.ConversationRegistry;
 import pro.zackpollard.telegrambot.api.event.ListenerRegistry;
 import pro.zackpollard.telegrambot.api.internal.chat.*;
 import pro.zackpollard.telegrambot.api.internal.chat.message.MessageImpl;
 import pro.zackpollard.telegrambot.api.internal.chat.message.send.FileContainer;
+import pro.zackpollard.telegrambot.api.internal.conversations.ConversationRegistryImpl;
 import pro.zackpollard.telegrambot.api.internal.event.ListenerRegistryImpl;
 import pro.zackpollard.telegrambot.api.internal.managers.FileManager;
 import pro.zackpollard.telegrambot.api.internal.updates.RequestUpdatesManager;
@@ -40,6 +42,8 @@ public final class TelegramBot {
     @Getter
     private final static FileManager fileManager = new FileManager();
 
+    @Getter
+    private final ConversationRegistry conversationRegistry;
     @Getter
     private final String authToken;
     private final ListenerRegistry listenerRegistry;
@@ -60,6 +64,7 @@ public final class TelegramBot {
         this.botUsername = botUsername;
 
         listenerRegistry = ListenerRegistryImpl.getNewInstance();
+        conversationRegistry = ConversationRegistryImpl.create();
     }
 
     /**

--- a/src/main/java/pro/zackpollard/telegrambot/api/conversations/Conversation.java
+++ b/src/main/java/pro/zackpollard/telegrambot/api/conversations/Conversation.java
@@ -1,5 +1,6 @@
 package pro.zackpollard.telegrambot.api.conversations;
 
+import lombok.Getter;
 import lombok.Setter;
 import pro.zackpollard.telegrambot.api.TelegramBot;
 import pro.zackpollard.telegrambot.api.chat.Chat;
@@ -12,13 +13,19 @@ import java.util.HashMap;
 import java.util.Map;
 
 public final class Conversation {
+    @Getter
     private final ConversationContext context;
+    @Getter
     private final Chat forWhom;
     @Setter
+    @Getter
     private boolean silent;
     @Setter
+    @Getter
     private boolean disableGlobalEvents;
+    @Getter
     private ConversationPrompt currentPrompt;
+    @Getter
     private final ConversationPrompt initialPrompt;
 
     private Conversation(TelegramBot bot, Map<String, Object> sessionData, Chat forWhom, boolean silent,
@@ -36,7 +43,7 @@ public final class Conversation {
     }
 
     public Conversation begin() {
-        context.bot().getConversationRegistry().registerConversation(this);
+        context.getBot().getConversationRegistry().registerConversation(this);
 
         if (!silent) {
             SendableMessage response = currentPrompt.promptMessage(context);
@@ -57,7 +64,7 @@ public final class Conversation {
         }
 
         currentPrompt = currentPrompt.process(context, content);
-        context.history().history.add(message);
+        context.getHistory().history.add(message);
 
         if (currentPrompt == null) {
             end();
@@ -76,31 +83,7 @@ public final class Conversation {
             currentPrompt = null;
         }
 
-        context.bot().getConversationRegistry().removeConversation(this);
-    }
-
-    public ConversationPrompt initialPrompt() {
-        return initialPrompt;
-    }
-
-    public ConversationPrompt currentPrompt() {
-        return currentPrompt;
-    }
-
-    public boolean silent() {
-        return silent;
-    }
-
-    public Chat forWhom() {
-        return forWhom;
-    }
-
-    public ConversationContext context() {
-        return context;
-    }
-
-    public boolean disableGlobalEvents() {
-        return disableGlobalEvents;
+        context.getBot().getConversationRegistry().removeConversation(this);
     }
 
     public static class ConversationBuilder {

--- a/src/main/java/pro/zackpollard/telegrambot/api/conversations/Conversation.java
+++ b/src/main/java/pro/zackpollard/telegrambot/api/conversations/Conversation.java
@@ -1,0 +1,145 @@
+package pro.zackpollard.telegrambot.api.conversations;
+
+import lombok.Setter;
+import pro.zackpollard.telegrambot.api.TelegramBot;
+import pro.zackpollard.telegrambot.api.chat.Chat;
+import pro.zackpollard.telegrambot.api.chat.message.Message;
+import pro.zackpollard.telegrambot.api.chat.message.content.Content;
+import pro.zackpollard.telegrambot.api.chat.message.send.SendableMessage;
+import pro.zackpollard.telegrambot.api.utils.Utils;
+
+import java.util.HashMap;
+import java.util.Map;
+
+public final class Conversation {
+    private final ConversationContext context;
+    private final Chat forWhom;
+    @Setter
+    private boolean silent;
+    @Setter
+    private boolean disableGlobalEvents;
+    private ConversationPrompt currentPrompt;
+    private final ConversationPrompt initialPrompt;
+
+    private Conversation(TelegramBot bot, Map<String, Object> sessionData, Chat forWhom, boolean silent,
+                        boolean disableGlobalEvents, ConversationPrompt currentPrompt, ConversationPrompt initialPrompt) {
+        this.context = new ConversationContext(this, bot, sessionData);
+        this.forWhom = forWhom;
+        this.currentPrompt = currentPrompt;
+        this.initialPrompt = initialPrompt;
+        this.silent = silent;
+        this.disableGlobalEvents = disableGlobalEvents;
+    }
+
+    public Conversation begin() {
+        context.bot().getConversationRegistry().registerConversation(this);
+
+        if (!silent) {
+            SendableMessage response = currentPrompt.promptMessage(context);
+
+            if (response != null) {
+                forWhom.sendMessage(response);
+            }
+        }
+
+        return this;
+    }
+
+    public void accept(Message message) {
+        Content content = message.getContent();
+
+        if (content.getType() != currentPrompt.type()) {
+            return;
+        }
+
+        currentPrompt = currentPrompt.process(context, content);
+        context.history().history.add(message);
+
+        if (currentPrompt == null) {
+            end();
+        } else {
+            SendableMessage promptMessage = currentPrompt.promptMessage(context);
+
+            if (!silent && promptMessage != null) {
+                forWhom.sendMessage(promptMessage);
+            }
+        }
+    }
+
+    public void end() {
+        if (currentPrompt != null) {
+            currentPrompt.conversationEnded(context);
+            currentPrompt = null;
+        }
+
+        context.bot().getConversationRegistry().removeConversation(this);
+    }
+
+    public ConversationPrompt initialPrompt() {
+        return initialPrompt;
+    }
+
+    public ConversationPrompt currentPrompt() {
+        return currentPrompt;
+    }
+
+    public boolean silent() {
+        return silent;
+    }
+
+    public Chat forWhom() {
+        return forWhom;
+    }
+
+    public ConversationContext context() {
+        return context;
+    }
+
+    public boolean disableGlobalEvents() {
+        return disableGlobalEvents;
+    }
+
+    public static class ConversationBuilder {
+        private final TelegramBot bot;
+        private Chat forWhom;
+        private ConversationPrompt initialPrompt;
+        private Map<String, Object> sessionData = new HashMap<>();
+        private boolean silent;
+        private boolean disableGlobalEvents;
+
+        ConversationBuilder(TelegramBot bot) {
+            this.bot = bot;
+        }
+
+        public ConversationBuilder forWhom(Chat chat) {
+            this.forWhom = chat;
+            return this;
+        }
+
+        public ConversationBuilder initialPrompt(ConversationPrompt prompt) {
+            this.initialPrompt = prompt;
+            return this;
+        }
+
+        public ConversationBuilder sessionData(Map<String, Object> data) {
+            this.sessionData = data;
+            return this;
+        }
+
+        public ConversationBuilder silent(boolean silent) {
+            this.silent = silent;
+            return this;
+        }
+
+        public ConversationBuilder disableGlobalEvents(boolean disableGlobalEvents) {
+            this.disableGlobalEvents = disableGlobalEvents;
+            return this;
+        }
+
+        public Conversation build() {
+            Utils.validateNotNull(bot, forWhom, initialPrompt);
+            return new Conversation(bot, sessionData, forWhom, silent, disableGlobalEvents,
+                    initialPrompt, initialPrompt);
+        }
+    }
+}

--- a/src/main/java/pro/zackpollard/telegrambot/api/conversations/Conversation.java
+++ b/src/main/java/pro/zackpollard/telegrambot/api/conversations/Conversation.java
@@ -31,6 +31,10 @@ public final class Conversation {
         this.disableGlobalEvents = disableGlobalEvents;
     }
 
+    public static ConversationBuilder builder(TelegramBot bot) {
+        return new ConversationBuilder(bot);
+    }
+
     public Conversation begin() {
         context.bot().getConversationRegistry().registerConversation(this);
 

--- a/src/main/java/pro/zackpollard/telegrambot/api/conversations/ConversationContext.java
+++ b/src/main/java/pro/zackpollard/telegrambot/api/conversations/ConversationContext.java
@@ -1,0 +1,49 @@
+package pro.zackpollard.telegrambot.api.conversations;
+
+import pro.zackpollard.telegrambot.api.TelegramBot;
+import pro.zackpollard.telegrambot.api.chat.Chat;
+
+import java.util.Map;
+
+public final class ConversationContext {
+    private final ConversationHistory history = ConversationHistory.create();
+    private final Conversation conversation;
+    private final Chat from;
+    private final TelegramBot bot;
+    private final Map<String, Object> conversationData;
+
+    ConversationContext(Conversation conversation, TelegramBot bot, Map<String, Object> conversationData) {
+        this.conversation = conversation;
+        this.from = conversation.forWhom();
+        this.bot = bot;
+        this.conversationData = conversationData;
+    }
+
+    public Chat from() {
+        return from;
+    }
+
+    public Conversation conversation() {
+        return conversation;
+    }
+
+    public ConversationHistory history() {
+        return history;
+    }
+
+    public TelegramBot bot() {
+        return bot;
+    }
+
+    public Object sessionDataBy(String key) {
+        return conversationData.get(key);
+    }
+
+    public void setSessionData(String key, Object value) {
+        conversationData.put(key, value);
+    }
+
+    public boolean hasDataBy(String key) {
+        return conversationData.containsKey(key);
+    }
+}

--- a/src/main/java/pro/zackpollard/telegrambot/api/conversations/ConversationContext.java
+++ b/src/main/java/pro/zackpollard/telegrambot/api/conversations/ConversationContext.java
@@ -1,38 +1,27 @@
 package pro.zackpollard.telegrambot.api.conversations;
 
+import lombok.Getter;
 import pro.zackpollard.telegrambot.api.TelegramBot;
 import pro.zackpollard.telegrambot.api.chat.Chat;
 
 import java.util.Map;
 
 public final class ConversationContext {
+    @Getter
     private final ConversationHistory history = ConversationHistory.create();
+    @Getter
     private final Conversation conversation;
+    @Getter
     private final Chat from;
+    @Getter
     private final TelegramBot bot;
     private final Map<String, Object> conversationData;
 
     ConversationContext(Conversation conversation, TelegramBot bot, Map<String, Object> conversationData) {
         this.conversation = conversation;
-        this.from = conversation.forWhom();
+        this.from = conversation.getForWhom();
         this.bot = bot;
         this.conversationData = conversationData;
-    }
-
-    public Chat from() {
-        return from;
-    }
-
-    public Conversation conversation() {
-        return conversation;
-    }
-
-    public ConversationHistory history() {
-        return history;
-    }
-
-    public TelegramBot bot() {
-        return bot;
     }
 
     public Object sessionDataBy(String key) {

--- a/src/main/java/pro/zackpollard/telegrambot/api/conversations/ConversationHistory.java
+++ b/src/main/java/pro/zackpollard/telegrambot/api/conversations/ConversationHistory.java
@@ -1,0 +1,33 @@
+package pro.zackpollard.telegrambot.api.conversations;
+
+import pro.zackpollard.telegrambot.api.chat.message.Message;
+
+import java.util.ArrayList;
+import java.util.List;
+
+public final class ConversationHistory {
+    final List<Message> history = new ArrayList<>();
+
+    private ConversationHistory() {
+    }
+
+    static ConversationHistory create() {
+        return new ConversationHistory();
+    }
+
+    public Message first() {
+        return history.get(0);
+    }
+
+    public Message messageAt(int index) {
+        return history.get(index);
+    }
+
+    public Message last() {
+        if (history.isEmpty()) {
+            return null;
+        }
+
+        return history.get(history.size() - 1);
+    }
+}

--- a/src/main/java/pro/zackpollard/telegrambot/api/conversations/ConversationPrompt.java
+++ b/src/main/java/pro/zackpollard/telegrambot/api/conversations/ConversationPrompt.java
@@ -5,10 +5,9 @@ import pro.zackpollard.telegrambot.api.chat.message.content.ContentType;
 import pro.zackpollard.telegrambot.api.chat.message.send.SendableMessage;
 
 public interface ConversationPrompt<T extends Content> {
-    ConversationPrompt END_CONVERSATION = null;
-
     ContentType type();
-    ConversationPrompt process(ConversationContext context, T input);
+    // return whether or not to repeat the prompt
+    boolean process(ConversationContext context, T input);
     SendableMessage promptMessage(ConversationContext context);
 
     default void conversationEnded(ConversationContext context) {

--- a/src/main/java/pro/zackpollard/telegrambot/api/conversations/ConversationPrompt.java
+++ b/src/main/java/pro/zackpollard/telegrambot/api/conversations/ConversationPrompt.java
@@ -1,0 +1,16 @@
+package pro.zackpollard.telegrambot.api.conversations;
+
+import pro.zackpollard.telegrambot.api.chat.message.content.Content;
+import pro.zackpollard.telegrambot.api.chat.message.content.ContentType;
+import pro.zackpollard.telegrambot.api.chat.message.send.SendableMessage;
+
+public interface ConversationPrompt<T extends Content> {
+    ConversationPrompt END_CONVERSATION = null;
+
+    ContentType type();
+    ConversationPrompt process(ConversationContext context, T input);
+    SendableMessage promptMessage(ConversationContext context);
+
+    default void conversationEnded(ConversationContext context) {
+    }
+}

--- a/src/main/java/pro/zackpollard/telegrambot/api/conversations/ConversationRegistry.java
+++ b/src/main/java/pro/zackpollard/telegrambot/api/conversations/ConversationRegistry.java
@@ -1,0 +1,9 @@
+package pro.zackpollard.telegrambot.api.conversations;
+
+import pro.zackpollard.telegrambot.api.chat.message.Message;
+
+public interface ConversationRegistry {
+    void registerConversation(Conversation conversation);
+    void removeConversation(Conversation conversation);
+    boolean processMessage(Message message);
+}

--- a/src/main/java/pro/zackpollard/telegrambot/api/conversations/prompt/AbstractIgnoringPrompt.java
+++ b/src/main/java/pro/zackpollard/telegrambot/api/conversations/prompt/AbstractIgnoringPrompt.java
@@ -5,14 +5,11 @@ import pro.zackpollard.telegrambot.api.conversations.ConversationContext;
 import pro.zackpollard.telegrambot.api.conversations.ConversationPrompt;
 
 public abstract class AbstractIgnoringPrompt<T extends Content> implements ConversationPrompt<T> {
-    private final ConversationPrompt nextPrompt;
-
-    protected AbstractIgnoringPrompt(ConversationPrompt nextPrompt) {
-        this.nextPrompt = nextPrompt;
+    protected AbstractIgnoringPrompt() {
     }
 
     @Override
-    public ConversationPrompt process(ConversationContext context, T input) {
-        return nextPrompt;
+    public boolean process(ConversationContext context, T input) {
+        return false;
     }
 }

--- a/src/main/java/pro/zackpollard/telegrambot/api/conversations/prompt/AbstractIgnoringPrompt.java
+++ b/src/main/java/pro/zackpollard/telegrambot/api/conversations/prompt/AbstractIgnoringPrompt.java
@@ -1,0 +1,18 @@
+package pro.zackpollard.telegrambot.api.conversations.prompt;
+
+import pro.zackpollard.telegrambot.api.chat.message.content.Content;
+import pro.zackpollard.telegrambot.api.conversations.ConversationContext;
+import pro.zackpollard.telegrambot.api.conversations.ConversationPrompt;
+
+public abstract class AbstractIgnoringPrompt<T extends Content> implements ConversationPrompt<T> {
+    private final ConversationPrompt nextPrompt;
+
+    protected AbstractIgnoringPrompt(ConversationPrompt nextPrompt) {
+        this.nextPrompt = nextPrompt;
+    }
+
+    @Override
+    public ConversationPrompt process(ConversationContext context, T input) {
+        return nextPrompt;
+    }
+}

--- a/src/main/java/pro/zackpollard/telegrambot/api/conversations/prompt/ContactPrompt.java
+++ b/src/main/java/pro/zackpollard/telegrambot/api/conversations/prompt/ContactPrompt.java
@@ -1,0 +1,12 @@
+package pro.zackpollard.telegrambot.api.conversations.prompt;
+
+import pro.zackpollard.telegrambot.api.chat.message.content.ContactContent;
+import pro.zackpollard.telegrambot.api.chat.message.content.ContentType;
+import pro.zackpollard.telegrambot.api.conversations.ConversationPrompt;
+
+public abstract class ContactPrompt implements ConversationPrompt<ContactContent> {
+    @Override
+    public ContentType type() {
+        return ContentType.CONTACT;
+    }
+}

--- a/src/main/java/pro/zackpollard/telegrambot/api/conversations/prompt/DocumentPrompt.java
+++ b/src/main/java/pro/zackpollard/telegrambot/api/conversations/prompt/DocumentPrompt.java
@@ -1,0 +1,12 @@
+package pro.zackpollard.telegrambot.api.conversations.prompt;
+
+import pro.zackpollard.telegrambot.api.chat.message.content.ContentType;
+import pro.zackpollard.telegrambot.api.chat.message.content.DocumentContent;
+import pro.zackpollard.telegrambot.api.conversations.ConversationPrompt;
+
+public abstract class DocumentPrompt implements ConversationPrompt<DocumentContent> {
+    @Override
+    public ContentType type() {
+        return ContentType.DOCUMENT;
+    }
+}

--- a/src/main/java/pro/zackpollard/telegrambot/api/conversations/prompt/ExactMatchPrompt.java
+++ b/src/main/java/pro/zackpollard/telegrambot/api/conversations/prompt/ExactMatchPrompt.java
@@ -1,0 +1,7 @@
+package pro.zackpollard.telegrambot.api.conversations.prompt;
+
+public abstract class ExactMatchPrompt extends RegexPrompt {
+    protected ExactMatchPrompt(String match) {
+        super("^" + match + "$");
+    }
+}

--- a/src/main/java/pro/zackpollard/telegrambot/api/conversations/prompt/IgnoringPrompt.java
+++ b/src/main/java/pro/zackpollard/telegrambot/api/conversations/prompt/IgnoringPrompt.java
@@ -4,22 +4,20 @@ import pro.zackpollard.telegrambot.api.chat.message.content.Content;
 import pro.zackpollard.telegrambot.api.chat.message.content.ContentType;
 import pro.zackpollard.telegrambot.api.chat.message.send.SendableMessage;
 import pro.zackpollard.telegrambot.api.conversations.ConversationContext;
-import pro.zackpollard.telegrambot.api.conversations.ConversationPrompt;
 import pro.zackpollard.telegrambot.api.utils.Utils;
 
 public final class IgnoringPrompt<T extends Content> extends AbstractIgnoringPrompt<T> {
     private ContentType type;
     private SendableMessage promptMessage;
 
-    private IgnoringPrompt(ConversationPrompt nextPrompt, ContentType type, SendableMessage promptMessage) {
-        super(nextPrompt);
-        Utils.validateNotNull(nextPrompt, type);
+    private IgnoringPrompt(ContentType type, SendableMessage promptMessage) {
+        Utils.validateNotNull(type);
         this.type = type;
         this.promptMessage = promptMessage;
     }
 
-    public static <T extends Content> IgnoringPrompt<T> create(ConversationPrompt nextPrompt, ContentType type, SendableMessage promptMessage) {
-        return new IgnoringPrompt<>(nextPrompt, type, promptMessage);
+    public static <T extends Content> IgnoringPrompt<T> create(ContentType type, SendableMessage promptMessage) {
+        return new IgnoringPrompt<>(type, promptMessage);
     }
 
     @Override

--- a/src/main/java/pro/zackpollard/telegrambot/api/conversations/prompt/IgnoringPrompt.java
+++ b/src/main/java/pro/zackpollard/telegrambot/api/conversations/prompt/IgnoringPrompt.java
@@ -1,0 +1,34 @@
+package pro.zackpollard.telegrambot.api.conversations.prompt;
+
+import pro.zackpollard.telegrambot.api.chat.message.content.Content;
+import pro.zackpollard.telegrambot.api.chat.message.content.ContentType;
+import pro.zackpollard.telegrambot.api.chat.message.send.SendableMessage;
+import pro.zackpollard.telegrambot.api.conversations.ConversationContext;
+import pro.zackpollard.telegrambot.api.conversations.ConversationPrompt;
+import pro.zackpollard.telegrambot.api.utils.Utils;
+
+public final class IgnoringPrompt<T extends Content> extends AbstractIgnoringPrompt<T> {
+    private ContentType type;
+    private SendableMessage promptMessage;
+
+    private IgnoringPrompt(ConversationPrompt nextPrompt, ContentType type, SendableMessage promptMessage) {
+        super(nextPrompt);
+        Utils.validateNotNull(nextPrompt, type);
+        this.type = type;
+        this.promptMessage = promptMessage;
+    }
+
+    public static <T extends Content> IgnoringPrompt<T> create(ConversationPrompt nextPrompt, ContentType type, SendableMessage promptMessage) {
+        return new IgnoringPrompt<>(nextPrompt, type, promptMessage);
+    }
+
+    @Override
+    public ContentType type() {
+        return type;
+    }
+
+    @Override
+    public SendableMessage promptMessage(ConversationContext context) {
+        return promptMessage;
+    }
+}

--- a/src/main/java/pro/zackpollard/telegrambot/api/conversations/prompt/LocationPrompt.java
+++ b/src/main/java/pro/zackpollard/telegrambot/api/conversations/prompt/LocationPrompt.java
@@ -1,0 +1,12 @@
+package pro.zackpollard.telegrambot.api.conversations.prompt;
+
+import pro.zackpollard.telegrambot.api.chat.message.content.ContentType;
+import pro.zackpollard.telegrambot.api.chat.message.content.LocationContent;
+import pro.zackpollard.telegrambot.api.conversations.ConversationPrompt;
+
+public abstract class LocationPrompt implements ConversationPrompt<LocationContent> {
+    @Override
+    public ContentType type() {
+        return ContentType.LOCATION;
+    }
+}

--- a/src/main/java/pro/zackpollard/telegrambot/api/conversations/prompt/NumericPrompt.java
+++ b/src/main/java/pro/zackpollard/telegrambot/api/conversations/prompt/NumericPrompt.java
@@ -14,7 +14,8 @@ public abstract class NumericPrompt extends TextValidatingPrompt {
 
     @Override
     protected boolean validate(ConversationContext context, TextContent input) {
-        return parseNumber(input.getContent()).floatValue() == Float.NaN ;
+        Number number = parseNumber(input.getContent());
+        return number.floatValue() == Float.NaN && validateNumber(context, number);
     }
 
     @Override
@@ -43,6 +44,7 @@ public abstract class NumericPrompt extends TextValidatingPrompt {
         return Float.NaN;
     }
 
+    protected abstract boolean validateNumber(ConversationContext context, Number input);
     protected abstract ConversationPrompt accept(ConversationContext context, Number input);
     protected abstract SendableMessage invalidInputMessage(ConversationContext context, TextContent input);
     protected abstract SendableMessage notNumericMessage(ConversationContext context, TextContent input);

--- a/src/main/java/pro/zackpollard/telegrambot/api/conversations/prompt/NumericPrompt.java
+++ b/src/main/java/pro/zackpollard/telegrambot/api/conversations/prompt/NumericPrompt.java
@@ -1,0 +1,49 @@
+package pro.zackpollard.telegrambot.api.conversations.prompt;
+
+import pro.zackpollard.telegrambot.api.chat.message.content.TextContent;
+import pro.zackpollard.telegrambot.api.chat.message.send.SendableMessage;
+import pro.zackpollard.telegrambot.api.conversations.ConversationContext;
+import pro.zackpollard.telegrambot.api.conversations.ConversationPrompt;
+
+import java.util.regex.Pattern;
+
+public abstract class NumericPrompt extends TextValidatingPrompt {
+    private static final Pattern INTEGER_PATTERN = Pattern.compile("^[1-9]{1,10}$");
+    private static final Pattern DOUBLE_PATTERN = Pattern.compile("^[1-9]{1,309}\\.[1-9]{1,2}$");
+    private static final Pattern FLOAT_PATTERN = Pattern.compile("^[1-9]{1,29}\\.[1-9]{3,9}$");
+
+    @Override
+    protected boolean validate(ConversationContext context, TextContent input) {
+        return parseNumber(input.getContent()).floatValue() == Float.NaN ;
+    }
+
+    @Override
+    protected SendableMessage invalidationMessage(ConversationContext context, TextContent input) {
+        return validate(null, input) ? notNumericMessage(context, input) : invalidInputMessage(context, input);
+    }
+
+    @Override
+    protected ConversationPrompt accept(ConversationContext context, TextContent input) {
+        return accept(context, parseNumber(input.getContent()));
+    }
+
+    protected Number parseNumber(String text) {
+        if (INTEGER_PATTERN.matcher(text).matches()) {
+            return Integer.parseInt(text);
+        }
+
+        if (DOUBLE_PATTERN.matcher(text).matches()) {
+            return Double.parseDouble(text);
+        }
+
+        if (FLOAT_PATTERN.matcher(text).matches()) {
+            return Float.parseFloat(text);
+        }
+
+        return Float.NaN;
+    }
+
+    protected abstract ConversationPrompt accept(ConversationContext context, Number input);
+    protected abstract SendableMessage invalidInputMessage(ConversationContext context, TextContent input);
+    protected abstract SendableMessage notNumericMessage(ConversationContext context, TextContent input);
+}

--- a/src/main/java/pro/zackpollard/telegrambot/api/conversations/prompt/NumericPrompt.java
+++ b/src/main/java/pro/zackpollard/telegrambot/api/conversations/prompt/NumericPrompt.java
@@ -3,7 +3,6 @@ package pro.zackpollard.telegrambot.api.conversations.prompt;
 import pro.zackpollard.telegrambot.api.chat.message.content.TextContent;
 import pro.zackpollard.telegrambot.api.chat.message.send.SendableMessage;
 import pro.zackpollard.telegrambot.api.conversations.ConversationContext;
-import pro.zackpollard.telegrambot.api.conversations.ConversationPrompt;
 
 import java.util.regex.Pattern;
 
@@ -15,16 +14,17 @@ public abstract class NumericPrompt extends TextValidatingPrompt {
     @Override
     protected boolean validate(ConversationContext context, TextContent input) {
         Number number = parseNumber(input.getContent());
-        return number.floatValue() == Float.NaN && validateNumber(context, number);
+        return number != null && validateNumber(context, number);
     }
 
     @Override
     protected SendableMessage invalidationMessage(ConversationContext context, TextContent input) {
-        return validate(null, input) ? notNumericMessage(context, input) : invalidInputMessage(context, input);
+        return parseNumber(input.getContent()) == null ? notNumericMessage(context, input) :
+                invalidInputMessage(context, input);
     }
 
     @Override
-    protected ConversationPrompt accept(ConversationContext context, TextContent input) {
+    protected boolean accept(ConversationContext context, TextContent input) {
         return accept(context, parseNumber(input.getContent()));
     }
 
@@ -41,11 +41,11 @@ public abstract class NumericPrompt extends TextValidatingPrompt {
             return Float.parseFloat(text);
         }
 
-        return Float.NaN;
+        return null;
     }
 
     protected abstract boolean validateNumber(ConversationContext context, Number input);
-    protected abstract ConversationPrompt accept(ConversationContext context, Number input);
+    protected abstract boolean accept(ConversationContext context, Number input);
     protected abstract SendableMessage invalidInputMessage(ConversationContext context, TextContent input);
     protected abstract SendableMessage notNumericMessage(ConversationContext context, TextContent input);
 }

--- a/src/main/java/pro/zackpollard/telegrambot/api/conversations/prompt/RegexPrompt.java
+++ b/src/main/java/pro/zackpollard/telegrambot/api/conversations/prompt/RegexPrompt.java
@@ -1,0 +1,23 @@
+package pro.zackpollard.telegrambot.api.conversations.prompt;
+
+import pro.zackpollard.telegrambot.api.chat.message.content.TextContent;
+import pro.zackpollard.telegrambot.api.conversations.ConversationContext;
+
+import java.util.regex.Pattern;
+
+public abstract class RegexPrompt extends TextValidatingPrompt {
+    protected final Pattern pattern;
+
+    protected RegexPrompt(String pattern) {
+        this(Pattern.compile(pattern));
+    }
+
+    protected RegexPrompt(Pattern pattern) {
+        this.pattern = pattern;
+    }
+
+    @Override
+    protected boolean validate(ConversationContext context, TextContent input) {
+        return pattern.matcher(input.getContent()).matches();
+    }
+}

--- a/src/main/java/pro/zackpollard/telegrambot/api/conversations/prompt/StickerPrompt.java
+++ b/src/main/java/pro/zackpollard/telegrambot/api/conversations/prompt/StickerPrompt.java
@@ -1,0 +1,12 @@
+package pro.zackpollard.telegrambot.api.conversations.prompt;
+
+import pro.zackpollard.telegrambot.api.chat.message.content.ContentType;
+import pro.zackpollard.telegrambot.api.chat.message.content.StickerContent;
+import pro.zackpollard.telegrambot.api.conversations.ConversationPrompt;
+
+public abstract class StickerPrompt implements ConversationPrompt<StickerContent> {
+    @Override
+    public ContentType type() {
+        return ContentType.STICKER;
+    }
+}

--- a/src/main/java/pro/zackpollard/telegrambot/api/conversations/prompt/TextPrompt.java
+++ b/src/main/java/pro/zackpollard/telegrambot/api/conversations/prompt/TextPrompt.java
@@ -1,0 +1,12 @@
+package pro.zackpollard.telegrambot.api.conversations.prompt;
+
+import pro.zackpollard.telegrambot.api.chat.message.content.ContentType;
+import pro.zackpollard.telegrambot.api.chat.message.content.TextContent;
+import pro.zackpollard.telegrambot.api.conversations.ConversationPrompt;
+
+public abstract class TextPrompt implements ConversationPrompt<TextContent> {
+    @Override
+    public ContentType type() {
+        return ContentType.TEXT;
+    }
+}

--- a/src/main/java/pro/zackpollard/telegrambot/api/conversations/prompt/TextValidatingPrompt.java
+++ b/src/main/java/pro/zackpollard/telegrambot/api/conversations/prompt/TextValidatingPrompt.java
@@ -17,7 +17,7 @@ public abstract class TextValidatingPrompt extends TextPrompt {
             SendableMessage message = invalidationMessage(context, input);
 
             if (message != null) {
-                context.from().sendMessage(message);
+                context.getFrom().sendMessage(message);
             }
 
             return this; // try again loser

--- a/src/main/java/pro/zackpollard/telegrambot/api/conversations/prompt/TextValidatingPrompt.java
+++ b/src/main/java/pro/zackpollard/telegrambot/api/conversations/prompt/TextValidatingPrompt.java
@@ -1,0 +1,30 @@
+package pro.zackpollard.telegrambot.api.conversations.prompt;
+
+import pro.zackpollard.telegrambot.api.chat.message.content.TextContent;
+import pro.zackpollard.telegrambot.api.chat.message.send.SendableMessage;
+import pro.zackpollard.telegrambot.api.conversations.ConversationContext;
+import pro.zackpollard.telegrambot.api.conversations.ConversationPrompt;
+
+public abstract class TextValidatingPrompt extends TextPrompt {
+    protected abstract boolean validate(ConversationContext context, TextContent input);
+    protected abstract ConversationPrompt accept(ConversationContext context, TextContent input);
+
+    @Override
+    public ConversationPrompt process(ConversationContext context, TextContent input) {
+        if (validate(context, input)) {
+            return accept(context, input);
+        } else {
+            SendableMessage message = invalidationMessage(context, input);
+
+            if (message != null) {
+                context.from().sendMessage(message);
+            }
+
+            return this; // try again loser
+        }
+    }
+
+    protected SendableMessage invalidationMessage(ConversationContext context, TextContent input) {
+        return null;
+    }
+}

--- a/src/main/java/pro/zackpollard/telegrambot/api/conversations/prompt/TextValidatingPrompt.java
+++ b/src/main/java/pro/zackpollard/telegrambot/api/conversations/prompt/TextValidatingPrompt.java
@@ -3,14 +3,13 @@ package pro.zackpollard.telegrambot.api.conversations.prompt;
 import pro.zackpollard.telegrambot.api.chat.message.content.TextContent;
 import pro.zackpollard.telegrambot.api.chat.message.send.SendableMessage;
 import pro.zackpollard.telegrambot.api.conversations.ConversationContext;
-import pro.zackpollard.telegrambot.api.conversations.ConversationPrompt;
 
 public abstract class TextValidatingPrompt extends TextPrompt {
     protected abstract boolean validate(ConversationContext context, TextContent input);
-    protected abstract ConversationPrompt accept(ConversationContext context, TextContent input);
+    protected abstract boolean accept(ConversationContext context, TextContent input);
 
     @Override
-    public ConversationPrompt process(ConversationContext context, TextContent input) {
+    public boolean process(ConversationContext context, TextContent input) {
         if (validate(context, input)) {
             return accept(context, input);
         } else {
@@ -20,7 +19,7 @@ public abstract class TextValidatingPrompt extends TextPrompt {
                 context.getFrom().sendMessage(message);
             }
 
-            return this; // try again loser
+            return true; // try again loser
         }
     }
 

--- a/src/main/java/pro/zackpollard/telegrambot/api/conversations/prompt/VenuePrompt.java
+++ b/src/main/java/pro/zackpollard/telegrambot/api/conversations/prompt/VenuePrompt.java
@@ -1,0 +1,12 @@
+package pro.zackpollard.telegrambot.api.conversations.prompt;
+
+import pro.zackpollard.telegrambot.api.chat.message.content.ContentType;
+import pro.zackpollard.telegrambot.api.chat.message.content.VenueContent;
+import pro.zackpollard.telegrambot.api.conversations.ConversationPrompt;
+
+public abstract class VenuePrompt implements ConversationPrompt<VenueContent> {
+    @Override
+    public ContentType type() {
+        return ContentType.VENUE;
+    }
+}

--- a/src/main/java/pro/zackpollard/telegrambot/api/internal/conversations/ConversationRegistryImpl.java
+++ b/src/main/java/pro/zackpollard/telegrambot/api/internal/conversations/ConversationRegistryImpl.java
@@ -19,14 +19,14 @@ public class ConversationRegistryImpl implements ConversationRegistry {
 
     @Override
     public void registerConversation(Conversation conversation) {
-        activeConversations.put(conversation.forWhom().getId(), conversation);
+        activeConversations.put(conversation.getForWhom().getId(), conversation);
     }
 
     @Override
     public void removeConversation(Conversation conversation) {
-        activeConversations.remove(conversation.forWhom().getId());
+        activeConversations.remove(conversation.getForWhom().getId());
 
-        if (conversation.currentPrompt() != null) {
+        if (conversation.getCurrentPrompt() != null) {
             conversation.end();
         }
     }
@@ -39,8 +39,8 @@ public class ConversationRegistryImpl implements ConversationRegistry {
             return false;
         }
 
-        if (conversation.currentPrompt().type() != message.getContent().getType()) {
-            return conversation.disableGlobalEvents();
+        if (conversation.getCurrentPrompt().type() != message.getContent().getType()) {
+            return conversation.isDisableGlobalEvents();
         }
 
         conversation.accept(message);

--- a/src/main/java/pro/zackpollard/telegrambot/api/internal/conversations/ConversationRegistryImpl.java
+++ b/src/main/java/pro/zackpollard/telegrambot/api/internal/conversations/ConversationRegistryImpl.java
@@ -1,0 +1,49 @@
+package pro.zackpollard.telegrambot.api.internal.conversations;
+
+import pro.zackpollard.telegrambot.api.chat.message.Message;
+import pro.zackpollard.telegrambot.api.conversations.Conversation;
+import pro.zackpollard.telegrambot.api.conversations.ConversationRegistry;
+
+import java.util.HashMap;
+import java.util.Map;
+
+public class ConversationRegistryImpl implements ConversationRegistry {
+    private final Map<String, Conversation> activeConversations = new HashMap<>();
+
+    private ConversationRegistryImpl() {
+    }
+
+    public static ConversationRegistry create() {
+        return new ConversationRegistryImpl();
+    }
+
+    @Override
+    public void registerConversation(Conversation conversation) {
+        activeConversations.put(conversation.forWhom().getId(), conversation);
+    }
+
+    @Override
+    public void removeConversation(Conversation conversation) {
+        activeConversations.remove(conversation.forWhom().getId());
+
+        if (conversation.currentPrompt() != null) {
+            conversation.end();
+        }
+    }
+
+    @Override
+    public boolean processMessage(Message message) {
+        Conversation conversation = activeConversations.get(message.getChat().getId());
+
+        if (conversation == null) {
+            return false;
+        }
+
+        if (conversation.currentPrompt().type() != message.getContent().getType()) {
+            return conversation.disableGlobalEvents();
+        }
+
+        conversation.accept(message);
+        return true;
+    }
+}

--- a/src/main/java/pro/zackpollard/telegrambot/api/internal/updates/RequestUpdatesManager.java
+++ b/src/main/java/pro/zackpollard/telegrambot/api/internal/updates/RequestUpdatesManager.java
@@ -124,6 +124,9 @@ public class RequestUpdatesManager extends UpdateManager {
                                 switch (update.getType()) {
 
                                     case MESSAGE: {
+                                        if (getBotInstance().getConversationRegistry().processMessage(update.getMessage())) {
+                                            break;
+                                        }
 
                                         eventManager.callEvent(new MessageReceivedEvent(update.getMessage()));
 

--- a/src/main/java/pro/zackpollard/telegrambot/api/utils/Utils.java
+++ b/src/main/java/pro/zackpollard/telegrambot/api/utils/Utils.java
@@ -115,4 +115,20 @@ public class Utils {
 
         return false;
     }
+
+    public static void validateNotNull(Object object) {
+        validateNotNull(object, "");
+    }
+
+    public static void validateNotNull(Object object, String message) {
+        if (object == null) {
+            throw new NullPointerException(message);
+        }
+    }
+
+    public static void validateNotNull(Object... objects) {
+        for (Object o : objects) {
+            validateNotNull(objects);
+        }
+    }
 }

--- a/src/main/java/pro/zackpollard/telegrambot/api/utils/Utils.java
+++ b/src/main/java/pro/zackpollard/telegrambot/api/utils/Utils.java
@@ -128,7 +128,7 @@ public class Utils {
 
     public static void validateNotNull(Object... objects) {
         for (Object o : objects) {
-            validateNotNull(objects);
+            validateNotNull(o);
         }
     }
 }


### PR DESCRIPTION
This request adds a conversation API that allows developers to add an easy way to follow-up prompts with the user. Here's an example of how it would be used:

``` java

// somewhere in code, probably a command
// disableGlobalEvents stops other events with this user from firing
// even if it did not get the message type it was looking for
        Conversation.builder(bot)
                .forWhom(event.getChat())
                .prompts()
                    .first(new EmailPrompt())
                    .then(new FavouriteNumberPrompt()) // then() can be called repeatedly
                    .last(new FavouriteStickerPrompt())
                .disableGlobalEvents(false)
                .build()
                .begin();

public class EmailPrompt extends RegexPrompt {
    public EmailPrompt() {
        super("[a-z0-9!#$%&'*+/=?^_`{|}~-]+(?:\\.[a-z0-9!#$%&'*+/=?^_`{|}~-]+)" +
                "*@(?:[a-z0-9](?:[a-z0-9-]*[a-z0-9])?\\.)" +
                "+[a-z0-9](?:[a-z0-9-]*[a-z0-9])?");
    }

    @Override
    protected boolean accept(ConversationContext context, TextContent input) {
        context.setSessionData("email", input.getContent());
        return false;
    }

    @Override
    public SendableMessage promptMessage(ConversationContext context) {
        return SendableTextMessage.builder()
                .message("What's your e-mail?")
                .build();
    }
}
```

The rest of the prompts and the code that ran the conversation below can be found [here](https://github.com/mkotb/TelegramConversations-Test):

[FavouriteNumberPrompt](https://github.com/mkotb/TelegramConversations-Test/blob/master/src/main/java/xyz/mkotb/tg/convo/FavouriteNumberPrompt.java)
[FavouriteStickerPrompt](https://github.com/mkotb/TelegramConversations-Test/blob/master/src/main/java/xyz/mkotb/tg/convo/FavouriteStickerPrompt.java)

And with that code, it the conversation will go as such:

![](https://i.imgur.com/i2iAJSr.png)
