### PR TITLE
Allow better support for conversations in groups

### DIFF
--- a/src/main/java/pro/zackpollard/telegrambot/api/conversations/Conversation.java
+++ b/src/main/java/pro/zackpollard/telegrambot/api/conversations/Conversation.java
@@ -6,11 +6,16 @@ import pro.zackpollard.telegrambot.api.TelegramBot;
 import pro.zackpollard.telegrambot.api.chat.Chat;
 import pro.zackpollard.telegrambot.api.chat.message.Message;
 import pro.zackpollard.telegrambot.api.chat.message.content.Content;
+import pro.zackpollard.telegrambot.api.chat.message.content.TextContent;
 import pro.zackpollard.telegrambot.api.chat.message.send.SendableMessage;
+import pro.zackpollard.telegrambot.api.chat.message.send.SendableTextMessage;
 import pro.zackpollard.telegrambot.api.user.User;
 import pro.zackpollard.telegrambot.api.utils.Utils;
 
 import java.util.*;
+import java.util.concurrent.TimeUnit;
+import java.util.function.BiConsumer;
+import java.util.function.BiPredicate;
 import java.util.function.Predicate;
 
 /**
@@ -21,6 +26,7 @@ import java.util.function.Predicate;
  * @see Conversation#builder(TelegramBot)
  */
 public final class Conversation {
+    private static final Timer TIMER = new Timer();
     /**
      * The index of the current prompt. Starts from 0 like an array index.
      * If promptIndex + 1 == prompt.size, there are no further prompts
@@ -61,6 +67,11 @@ public final class Conversation {
     @Getter
     private ConversationPrompt currentPrompt;
     /**
+     * Has the conversation ended yet?
+     */
+    @Getter
+    private boolean virgin = true;
+    /**
      * The prompts to be called during the conversation, do not attempt to modify this list.
      * Is processed through Collections.unmodifiableList
      *
@@ -76,10 +87,22 @@ public final class Conversation {
      * Forces all messages that are processed by the conversation to be replies
      */
     private final boolean repliesOnly;
+    /**
+     * Executed when the conversation is ended for somewhatever reason.
+     * Regardless of the current prompt.
+     */
+    private final BiConsumer<Conversation, ConversationContext> endCallback;
+    /**
+     * Called with every input, if returns true, the conversation will be ended.
+     */
+    private final BiPredicate<ConversationContext, Content> endPredicate;
 
     private Conversation(TelegramBot bot, Map<String, Object> sessionData, Chat forWhom, boolean silent,
                         boolean disableGlobalEvents, List<ConversationPrompt> prompts,
-                         Predicate<User> userPredicate, boolean repliesOnly) {
+                         Predicate<User> userPredicate, boolean repliesOnly,
+                         BiConsumer<Conversation, ConversationContext> endCallback,
+                         BiPredicate<ConversationContext, Content> endPredicate,
+                         long timeout, SendableMessage timeoutMessage) {
         this.forWhom = forWhom;
         this.context = new ConversationContext(this, bot, sessionData);
         this.currentPrompt = prompts.get(promptIndex);
@@ -88,6 +111,23 @@ public final class Conversation {
         this.disableGlobalEvents = disableGlobalEvents;
         this.userPredicate = (userPredicate == null) ? (user) -> true : userPredicate;
         this.repliesOnly = repliesOnly;
+        this.endCallback = endCallback;
+        this.endPredicate = endPredicate;
+
+        if (timeout > 0) {
+            TIMER.schedule(new TimerTask() {
+                @Override
+                public void run() {
+                    if (isVirgin()) {
+                        if (timeoutMessage != null) {
+                            sendMessage(timeoutMessage);
+                        }
+
+                        end();
+                    }
+                }
+            }, TimeUnit.SECONDS.toMillis(timeout));
+        }
     }
 
     /**
@@ -105,6 +145,10 @@ public final class Conversation {
      * @return The current conversation
      */
     public Conversation begin() {
+        if (!virgin) {
+            throw new IllegalStateException("You can only start a virgin conversation!");
+        }
+
         context.getBot().getConversationRegistry().registerConversation(this);
 
         if (!silent) {
@@ -130,11 +174,16 @@ public final class Conversation {
     public boolean accept(Message message) {
         Content content = message.getContent();
 
-        if (content.getType() != currentPrompt.type()) {
+        if (!userPredicate.test(message.getSender())) {
             return false;
         }
 
-        if (!userPredicate.test(message.getSender())) {
+        if (endPredicate != null && endPredicate.test(context, content)) {
+            end();
+            return true;
+        }
+
+        if (content.getType() != currentPrompt.type()) {
             return false;
         }
 
@@ -172,12 +221,17 @@ public final class Conversation {
      * @see ConversationPrompt#conversationEnded(ConversationContext)
      */
     public void end() {
+        if (endCallback != null) {
+            endCallback.accept(this, context);
+        }
+
         if (currentPrompt != null) {
             currentPrompt.conversationEnded(context);
             currentPrompt = null;
         }
 
         context.getBot().getConversationRegistry().removeConversation(this);
+        virgin = false;
     }
 
     private void sendMessage(SendableMessage message) {
@@ -200,9 +254,79 @@ public final class Conversation {
         private boolean disableGlobalEvents;
         private boolean repliesOnly = false;
         private Predicate<User> userPredicate;
+        private BiConsumer<Conversation, ConversationContext> endCallback;
+        private BiPredicate<ConversationContext, Content> endPredicate;
+        private long timeout = -1;
+        private SendableMessage timeoutMessage;
 
         ConversationBuilder(TelegramBot bot) {
             this.bot = bot;
+        }
+
+        /**
+         * Timeout in seconds for the conversation to be finished.
+         * If the conversation is not finished, it will be ended.
+         *
+         * @param timeout Timeout in seconds
+         */
+        public ConversationBuilder conservationTimeout(long timeout) {
+            return conversationTimeout(timeout, null);
+        }
+
+        /**
+         * Timeout in seconds for the conversation to be finished.
+         * If the conversation is not finished, it will be ended and the message provided will be sent.
+         *
+         * @param timeout Timeout in seconds
+         * @param message Message to be sent if the conversation is timed out
+         */
+        public ConversationBuilder conversationTimeout(long timeout, SendableMessage message) {
+            this.timeout = timeout;
+            this.timeoutMessage = message;
+            return this;
+        }
+
+        public ConversationBuilder endCommand(String command) {
+            return endText(command.charAt(0) == '/' ? command : "/" + command);
+        }
+
+        public ConversationBuilder endText(String text) {
+            return endText(text, true);
+        }
+
+        public ConversationBuilder endText(String text, boolean ignoreCase) {
+            return endText((string) -> ignoreCase ? text.equalsIgnoreCase(string) : text.equals(string));
+        }
+
+        /**
+         * Called with every input, if returns true, the conversation will be ended.
+         */
+        public ConversationBuilder endText(Predicate<String> textPredicate) {
+            return endPredicate((context, content) -> content instanceof TextContent &&
+                    textPredicate.test(((TextContent) content).getContent()));
+        }
+
+        public ConversationBuilder endPredicate(BiPredicate<ConversationContext, Content> predicate) {
+            this.endPredicate = predicate;
+            return this;
+        }
+
+        /**
+         * The message that is sent when the conversation ends.
+         *
+         * Not to be confused with endText which is the text that if sent by the user,
+         * the conversation will be ended.
+         *
+         * @param message Message to be sent when the conversation ends.
+         * @return Current Builder
+         */
+        public ConversationBuilder endingMessage(SendableTextMessage message) {
+            return endCallback((conv, context) -> conv.sendMessage(message));
+        }
+
+        public ConversationBuilder endCallback(BiConsumer<Conversation, ConversationContext> callback) {
+            this.endCallback = callback;
+            return this;
         }
 
         /**
@@ -312,7 +436,8 @@ public final class Conversation {
         public Conversation build() {
             Utils.validateNotNull(bot, forWhom, prompts);
             return new Conversation(bot, sessionData, forWhom, silent, disableGlobalEvents,
-                    prompts, userPredicate, repliesOnly);
+                    prompts, userPredicate, repliesOnly, endCallback, endPredicate,
+                    timeout, timeoutMessage);
         }
     }
 

--- a/src/main/java/pro/zackpollard/telegrambot/api/conversations/Conversation.java
+++ b/src/main/java/pro/zackpollard/telegrambot/api/conversations/Conversation.java
@@ -141,7 +141,7 @@ public final class Conversation {
         if (repliesOnly) {
             Message repliedTo = message.getRepliedTo();
 
-            if (repliedTo == null || !context.getHistory().sentMessages.contains(repliedTo.getMessageId())) {
+            if (repliedTo == null || repliedTo.getSender().getUsername().equals(context.getBot().getBotUsername())) {
                 return false;
             }
         }

--- a/src/main/java/pro/zackpollard/telegrambot/api/conversations/ConversationHistory.java
+++ b/src/main/java/pro/zackpollard/telegrambot/api/conversations/ConversationHistory.java
@@ -2,7 +2,7 @@ package pro.zackpollard.telegrambot.api.conversations;
 
 import pro.zackpollard.telegrambot.api.chat.message.Message;
 
-import java.util.ArrayList;
+import java.util.LinkedList;
 import java.util.List;
 
 /**
@@ -10,7 +10,8 @@ import java.util.List;
  * @author Mazen Kotb
  */
 public final class ConversationHistory {
-    final List<Message> history = new ArrayList<>();
+    final List<Long> sentMessages = new LinkedList<>();
+    final List<Message> history = new LinkedList<>();
 
     private ConversationHistory() {
     }


### PR DESCRIPTION
- A user filter was added to only have a select set of user(s) be part of the conversation in a group
- A `repliesOnly` field was added to have it so only messages which replied to a message sent by a bot will invoke prompts
- Allow multiple conversations to be active at the same time in the internals
