### PR TITLE
Add text builder for ease of use to format messages

### DIFF
--- a/src/main/java/pro/zackpollard/telegrambot/api/chat/message/send/SendableTextMessage.java
+++ b/src/main/java/pro/zackpollard/telegrambot/api/chat/message/send/SendableTextMessage.java
@@ -56,6 +56,125 @@ public class SendableTextMessage implements SendableMessage, ReplyingOptions, No
         return MessageType.TEXT;
     }
 
+    public static class SendableTextBuilder {
+        private final SendableTextMessageBuilder parent;
+        private final StringBuilder message = new StringBuilder();
+
+        SendableTextBuilder(SendableTextMessageBuilder parent) {
+            this.parent = parent;
+        }
+
+        private String htmlEscaped(String text) {
+            return text.replace("&", "&amp;").replace("<", "&lt;").replace(">", "&gt;");
+        }
+
+        private SendableTextBuilder element(String e, String content) {
+            // for the closing element, split(" ")[0] is used in case of parameters
+            // that are used like linking
+            message.append("<").append(e).append(">").append(htmlEscaped(content)).append("</").append(e.split(" ")[0]).append(">");
+            return this;
+        }
+
+        public SendableTextBuilder plain(String text) {
+            return escaped(text);
+        }
+
+        /**
+         * Appends text as escaped text, no formatting.
+         *
+         * @param text Text to append and escape
+         */
+        public SendableTextBuilder escaped(String text) {
+            return html(htmlEscaped(text));
+        }
+
+        /**
+         * Text to take in and parse as HTML-formatted text.
+         *
+         * @param html Text to append and parse as HTML
+         */
+        public SendableTextBuilder html(String html) {
+            message.append(html);
+            return this;
+        }
+
+        /**
+         * Appends text and makes it bold. Text is escaped.
+         * @param text Text to append
+         */
+        public SendableTextBuilder bold(String text) {
+            return element("b", text);
+        }
+
+        /**
+         * Appends text and makes it italic. Text is escaped.
+         * @param text Text to append
+         */
+        public SendableTextBuilder italics(String text) {
+            return element("i", text);
+        }
+
+        /**
+         * Appends an inline URL in the text
+         * @param text Text to link. Text is escaped
+         * @param link Link to reference
+         */
+        public SendableTextBuilder link(String text, String link) {
+            return element("a href=\"" + link + "\"", text);
+        }
+
+        /**
+         * Appends inline-code to the text
+         * @param text Text to format. Escaped.
+         */
+        public SendableTextBuilder code(String text) {
+            return element("code", text);
+        }
+
+        /**
+         * Appends pre-formatted fixed-width code block.
+         * @param text Text to format. Escaped
+         */
+        public SendableTextBuilder preformatted(String text) {
+            return element("pre", text);
+        }
+
+        /**
+         * Appends a space.
+         */
+        public SendableTextBuilder space() {
+            message.append(' ');
+            return this;
+        }
+
+        /**
+         * Appends a new line
+         */
+        public SendableTextBuilder newLine() {
+            message.append("\n");
+            return this;
+        }
+
+        /**
+         * Alias for newLine()
+         */
+        public SendableTextBuilder nextLine() {
+            return newLine();
+        }
+
+        /**
+         * Set the SendableTextMessageBuilder's text to the created text.
+         * ParseMode must be HTML!
+         *
+         * @return SendableTextMessageBuilder instance
+         */
+        public SendableTextMessageBuilder buildText() {
+            parent.message = message.toString();
+            parent.parseMode = ParseMode.HTML;
+            return parent;
+        }
+    }
+
     @ToString
     public static class SendableTextMessageBuilder {
 
@@ -67,6 +186,10 @@ public class SendableTextMessage implements SendableMessage, ReplyingOptions, No
         private boolean disableNotification;
 
         SendableTextMessageBuilder() {
+        }
+
+        public SendableTextBuilder textBuilder() {
+            return new SendableTextBuilder(this);
         }
 
         /**


### PR DESCRIPTION
Recently in a discussion, we were facing the issue with escaping and formatting in Markdown and said it's probably best to format with HTML, but it's [such a pain](https://github.com/mkotb/DicktonaryBot/blob/master/src/main/java/xyz/mkotb/dicktionary/DicktionaryDefinition.java#L71-L106) at the moment with the current system. So, I thought a builder could make it so much easier and convenient, and that's what this addition does. The code would be:

![](https://i.imgur.com/Z5TMVX3.png)

and that creates this:

![](https://i.imgur.com/Km5N7LW.png)

While this is a very trivial case, in cases where escaping and formatting come to intertwine, this addition will come in great use.