### PR TITLE
Feature/supporting channel posts

### DIFF
--- a/src/main/java/pro/zackpollard/telegrambot/api/event/Listener.java
+++ b/src/main/java/pro/zackpollard/telegrambot/api/event/Listener.java
@@ -40,6 +40,9 @@ public interface Listener {
 
     default void onTextMessageReceived(TextMessageReceivedEvent event) {
     }
+    
+    default void onChannelPostReceived(ChannelPostReceivedEvent event) {
+    }
 
     default void onVideoMessageReceived(VideoMessageReceivedEvent event) {
     }

--- a/src/main/java/pro/zackpollard/telegrambot/api/event/chat/message/ChannelPostReceivedEvent.java
+++ b/src/main/java/pro/zackpollard/telegrambot/api/event/chat/message/ChannelPostReceivedEvent.java
@@ -1,0 +1,26 @@
+package pro.zackpollard.telegrambot.api.event.chat.message;
+
+import pro.zackpollard.telegrambot.api.chat.message.Message;
+import pro.zackpollard.telegrambot.api.chat.message.content.TextContent;
+
+/**
+ * @author Zack Pollard
+ */
+public class ChannelPostReceivedEvent extends MessageReceivedEvent {
+
+    public ChannelPostReceivedEvent(Message message) {
+
+        super(message);
+    }
+
+    /**
+     * Gets the Text that was received that triggered this Event
+     *
+     * @return The Text that was received that triggered this Event
+     */
+    @Override
+    public TextContent getContent() {
+
+        return (TextContent) getMessage().getContent();
+    }
+}

--- a/src/main/java/pro/zackpollard/telegrambot/api/internal/chat/ChatImpl.java
+++ b/src/main/java/pro/zackpollard/telegrambot/api/internal/chat/ChatImpl.java
@@ -11,7 +11,7 @@ public class ChatImpl {
 
     public static Chat createChat(JSONObject jsonObject, TelegramBot telegramBot) {
 
-        if(jsonObject != null) {
+        if (jsonObject != null) {
 
             String chatType = jsonObject.getString("type");
 
@@ -22,7 +22,11 @@ public class ChatImpl {
                 case "group":
                     return GroupChatImpl.createGroupChat(jsonObject, telegramBot);
                 case "channel":
-                    return ChannelChatImpl.createChannelChat(jsonObject, telegramBot);
+                    if (jsonObject.optString("username") == null || jsonObject.optString("username").isEmpty()) {
+                        return PrivateChannelChatImpl.createChannelChat(jsonObject, telegramBot);
+                    } else {
+                        return ChannelChatImpl.createChannelChat(jsonObject, telegramBot);
+                    }
                 case "supergroup":
                     return SuperGroupChatImpl.createSuperGroupChat(jsonObject, telegramBot);
                 default:

--- a/src/main/java/pro/zackpollard/telegrambot/api/internal/chat/PrivateChannelChatImpl.java
+++ b/src/main/java/pro/zackpollard/telegrambot/api/internal/chat/PrivateChannelChatImpl.java
@@ -9,21 +9,21 @@ import pro.zackpollard.telegrambot.api.chat.message.send.SendableMessage;
 /**
  * @author Zack Pollard
  */
-public class ChannelChatImpl implements ChannelChat {
+public class PrivateChannelChatImpl implements ChannelChat {
 
     private final String username;
     private final String title;
 
     private final TelegramBot telegramBot;
 
-    private ChannelChatImpl(JSONObject jsonObject, TelegramBot telegramBot) {
+    private PrivateChannelChatImpl(JSONObject jsonObject, TelegramBot telegramBot) {
 
-        this.username = "@" + jsonObject.optString("username");
+        this.username = jsonObject.optString("id");
         this.title = jsonObject.getString("title");
         this.telegramBot = telegramBot;
     }
 
-    private ChannelChatImpl(String username, TelegramBot telegramBot) {
+    private PrivateChannelChatImpl(String username, TelegramBot telegramBot) {
 
         this.username = username;
         this.title = null;
@@ -32,12 +32,12 @@ public class ChannelChatImpl implements ChannelChat {
 
     public static ChannelChat createChannelChat(JSONObject jsonObject, TelegramBot telegramBot) {
 
-        return new ChannelChatImpl(jsonObject, telegramBot);
+        return new PrivateChannelChatImpl(jsonObject, telegramBot);
     }
 
     public static ChannelChat createChannelChat(String username, TelegramBot telegramBot) {
 
-        return new ChannelChatImpl(username, telegramBot);
+        return new PrivateChannelChatImpl(username, telegramBot);
     }
 
     @Override

--- a/src/main/java/pro/zackpollard/telegrambot/api/internal/chat/PrivateChannelChatImpl.java
+++ b/src/main/java/pro/zackpollard/telegrambot/api/internal/chat/PrivateChannelChatImpl.java
@@ -1,0 +1,68 @@
+package pro.zackpollard.telegrambot.api.internal.chat;
+
+import org.json.JSONObject;
+import pro.zackpollard.telegrambot.api.TelegramBot;
+import pro.zackpollard.telegrambot.api.chat.ChannelChat;
+import pro.zackpollard.telegrambot.api.chat.message.Message;
+import pro.zackpollard.telegrambot.api.chat.message.send.SendableMessage;
+
+/**
+ * @author Zack Pollard
+ */
+public class ChannelChatImpl implements ChannelChat {
+
+    private final String username;
+    private final String title;
+
+    private final TelegramBot telegramBot;
+
+    private ChannelChatImpl(JSONObject jsonObject, TelegramBot telegramBot) {
+
+        this.username = "@" + jsonObject.optString("username");
+        this.title = jsonObject.getString("title");
+        this.telegramBot = telegramBot;
+    }
+
+    private ChannelChatImpl(String username, TelegramBot telegramBot) {
+
+        this.username = username;
+        this.title = null;
+        this.telegramBot = telegramBot;
+    }
+
+    public static ChannelChat createChannelChat(JSONObject jsonObject, TelegramBot telegramBot) {
+
+        return new ChannelChatImpl(jsonObject, telegramBot);
+    }
+
+    public static ChannelChat createChannelChat(String username, TelegramBot telegramBot) {
+
+        return new ChannelChatImpl(username, telegramBot);
+    }
+
+    @Override
+    public String getUsername() {
+        return username;
+    }
+
+    @Override
+    public String getName() {
+        return title;
+    }
+
+    @Override
+    public TelegramBot getBotInstance() {
+        return telegramBot;
+    }
+
+    @Override
+    public String getId() {
+        return username;
+    }
+
+    @Override
+    public Message sendMessage(SendableMessage message) {
+
+        return telegramBot.sendMessage(this, message);
+    }
+}

--- a/src/main/java/pro/zackpollard/telegrambot/api/internal/event/ListenerRegistryImpl.java
+++ b/src/main/java/pro/zackpollard/telegrambot/api/internal/event/ListenerRegistryImpl.java
@@ -30,6 +30,7 @@ public class ListenerRegistryImpl implements ListenerRegistry {
             register(PhotoMessageReceivedEvent.class, Listener::onPhotoMessageReceived);
             register(StickerMessageReceivedEvent.class, Listener::onStickerMessageReceived);
             register(TextMessageReceivedEvent.class, Listener::onTextMessageReceived);
+            register(ChannelPostReceivedEvent.class, Listener::onChannelPostReceived);
             register(VideoMessageReceivedEvent.class, Listener::onVideoMessageReceived);
             register(VoiceMessageReceivedEvent.class, Listener::onVoiceMessageReceived);
 

--- a/src/main/java/pro/zackpollard/telegrambot/api/internal/updates/RequestUpdatesManager.java
+++ b/src/main/java/pro/zackpollard/telegrambot/api/internal/updates/RequestUpdatesManager.java
@@ -36,9 +36,11 @@ public class RequestUpdatesManager extends UpdateManager {
 
     public boolean startUpdates() {
 
-        if(this.eventManager == null) this.eventManager = (ListenerRegistryImpl) getBotInstance().getEventsManager();
+        if (this.eventManager == null) {
+            this.eventManager = (ListenerRegistryImpl) getBotInstance().getEventsManager();
+        }
 
-        if(updaterThread == null && !this.running) {
+        if (updaterThread == null && !this.running) {
 
             updaterThread = new Thread(new UpdaterRunnable(this.getPreviousUpdates));
             updaterThread.start();
@@ -116,8 +118,9 @@ public class RequestUpdatesManager extends UpdateManager {
 
                         JSONArray updates = jsonResponse.getJSONArray("result");
 
-                        if (updates.length() != 0)
+                        if (updates.length() != 0) {
                             offset = updates.getJSONObject(updates.length() - 1).getInt("update_id");
+                        }
 
                         if (!getPreviousUpdates) {
 
@@ -214,6 +217,29 @@ public class RequestUpdatesManager extends UpdateManager {
                                                 break;
                                         }
                                         break;
+                                    }
+
+                                    case CHANNEL_POST: {
+                                        if (getBotInstance().getConversationRegistry().processMessage(update.getChannelPost())) {
+                                            break;
+                                        }
+
+                                        eventManager.callEvent(new MessageReceivedEvent(update.getChannelPost()));
+
+                                        switch (update.getChannelPost().getContent().getType()) {
+                                            case TEXT: {
+
+                                                if (((TextContent) update.getChannelPost().getContent()).getContent().startsWith("/")) {
+
+                                                    eventManager.callEvent(new CommandMessageReceivedEvent(update.getChannelPost()));
+                                                } else {
+
+                                                    eventManager.callEvent(new ChannelPostReceivedEvent(update.getChannelPost()));
+                                                }
+
+                                                break;
+                                            }
+                                        }
                                     }
 
                                     case EDITED_MESSAGE: {

--- a/src/main/java/pro/zackpollard/telegrambot/api/internal/updates/UpdateImpl.java
+++ b/src/main/java/pro/zackpollard/telegrambot/api/internal/updates/UpdateImpl.java
@@ -20,6 +20,7 @@ public class UpdateImpl implements Update {
     private final int update_id;
     private final Message message;
     private final Message edited_message;
+    private final Message channel_post;
     private final InlineQuery inline_query;
     private final ChosenInlineResult chosen_inline_result;
     private final CallbackQuery callbackQuery;
@@ -34,6 +35,8 @@ public class UpdateImpl implements Update {
         if (message != null) updateType = UpdateType.MESSAGE;
         this.edited_message = MessageImpl.createMessage(jsonObject.optJSONObject("edited_message"), telegramBot);
         if (edited_message != null) updateType = UpdateType.EDITED_MESSAGE;
+        this.channel_post = MessageImpl.createMessage(jsonObject.optJSONObject("channel_post"), telegramBot);
+        if (channel_post != null) updateType = UpdateType.CHANNEL_POST;
         this.inline_query = InlineQueryImpl.createInlineQuery(jsonObject.optJSONObject("inline_query"));
         if (inline_query != null && updateType == null) updateType = UpdateType.INLINE_QUERY;
         this.chosen_inline_result = ChosenInlineResultImpl.createChosenInlineResult(jsonObject.optJSONObject("chosen_inline_result"));
@@ -61,8 +64,14 @@ public class UpdateImpl implements Update {
         return message;
     }
 
+    @Override
     public Message getEditedMessage() {
         return edited_message;
+    }
+
+    @Override
+    public Message getChannelPost() {
+        return channel_post;
     }
 
     @Override

--- a/src/main/java/pro/zackpollard/telegrambot/api/updates/Update.java
+++ b/src/main/java/pro/zackpollard/telegrambot/api/updates/Update.java
@@ -35,6 +35,13 @@ public interface Update {
     Message getEditedMessage();
 
     /**
+     * Gets the Channel Post Message that this Update contains.
+     *
+     * @return Channel Post message
+     */
+    Message getChannelPost();
+
+    /**
      * Gets the new incoming inline query
      *
      * @return The new incoming inline query
@@ -75,6 +82,7 @@ public interface Update {
         EDITED_MESSAGE,
         INLINE_QUERY,
         CALLBACK_QUERY,
-        CHOSEN_INLINE_RESULT
+        CHOSEN_INLINE_RESULT,
+        CHANNEL_POST
     }
 }


### PR DESCRIPTION
I have added support for the Channel Posts, whenever I receive a post from a channel I get a NullPointerException, so I extended your last version to support channels and to distinguish between public and private channels since the first one uses username while the other uses chat id.