### PR TITLE
Allow sending of InputStreams via InputFile

### DIFF
--- a/src/main/java/pro/zackpollard/telegrambot/api/TelegramBot.java
+++ b/src/main/java/pro/zackpollard/telegrambot/api/TelegramBot.java
@@ -226,7 +226,7 @@ public final class TelegramBot {
                             .field("chat_id", chat.getId(), "application/json; charset=utf8;");
 
                     InputFile inputFile = photoMessage.getPhoto();
-                    field(request, "photo", inputFile);
+                    Utils.field(request, "photo", inputFile);
 
                     if (photoMessage.getCaption() != null)
                         request.field("caption", photoMessage.getCaption(), "application/json; charset=utf8;");
@@ -281,7 +281,7 @@ public final class TelegramBot {
                             .field("chat_id", chat.getId(), "application/json; charset=utf8;");
 
                     InputFile inputFile = audioMessage.getAudio();
-                    field(request, "audio", inputFile);
+                    Utils.field(request, "audio", inputFile);
 
                     Utils.processReplyContent(request, audioMessage);
                     Utils.processNotificationContent(request, audioMessage);
@@ -335,7 +335,7 @@ public final class TelegramBot {
                             .field("chat_id", chat.getId(), "application/json; charset=utf8;");
 
                     InputFile inputFile = documentMessage.getDocument();
-                    field(request, "document", inputFile);
+                    Utils.field(request, "document", inputFile);
 
                     if (documentMessage.getCaption() != null)
                         request.field("caption", documentMessage.getCaption(), "application/json; charset=utf8;");
@@ -383,7 +383,7 @@ public final class TelegramBot {
                             .field("chat_id", chat.getId(), "application/json; charset=utf8;");
 
                     InputFile inputFile = stickerMessage.getSticker();
-                    field(request, "sticker", inputFile);
+                    Utils.field(request, "sticker", inputFile);
 
                     Utils.processReplyContent(request, stickerMessage);
                     Utils.processNotificationContent(request, stickerMessage);
@@ -421,7 +421,7 @@ public final class TelegramBot {
                             .field("chat_id", chat.getId(), "application/json; charset=utf8;");
 
                     InputFile inputFile = videoMessage.getVideo();
-                    field(request, "video", inputFile);
+                    Utils.field(request, "video", inputFile);
 
                     if (videoMessage.getDuration() > 0) request.field("duration", videoMessage.getDuration());
                     if (videoMessage.getWidth() > 0) request.field("width", videoMessage.getWidth());
@@ -465,7 +465,7 @@ public final class TelegramBot {
                             .field("chat_id", chat.getId(), "application/json; charset=utf8;");
 
                     InputFile inputFile = voiceMessage.getVoice();
-                    field(request, "voice", inputFile);
+                    Utils.field(request, "voice", inputFile);
 
                     if (voiceMessage.getDuration() > 0) request.field("duration", voiceMessage.getDuration());
 
@@ -566,17 +566,6 @@ public final class TelegramBot {
         }
 
         return Utils.checkResponseStatus(jsonResponse) ? (messageResponse != null ? messageResponse : MessageImpl.createMessage(jsonResponse, this)) : null;
-    }
-
-    private void field(MultipartBody request, String fieldName, InputFile inputFile) {
-        String fileId = inputFile.getFileID();
-        if (fileId != null) {
-            request.field(fieldName, fileId, false);
-        } else if (inputFile.getInputStream() != null) {
-            request.field(fieldName, new InputStreamBody(inputFile.getInputStream(), inputFile.getFileName()), true);
-        } else { // assume file is not null (this is existing behaviour as of 1.5.1)
-            request.field(fieldName, new FileContainer(inputFile), true);
-        }
     }
 
     private JSONObject editMessageText(String chatId, Long messageId, String inlineMessageId, String text, ParseMode parseMode, boolean disableWebPagePreview, InlineReplyMarkup inlineReplyMarkup) {

--- a/src/main/java/pro/zackpollard/telegrambot/api/TelegramBot.java
+++ b/src/main/java/pro/zackpollard/telegrambot/api/TelegramBot.java
@@ -226,14 +226,7 @@ public final class TelegramBot {
                             .field("chat_id", chat.getId(), "application/json; charset=utf8;");
 
                     InputFile inputFile = photoMessage.getPhoto();
-                    String fileId = inputFile.getFileID();
-                    if (fileId != null) {
-                        request.field("photo", fileId, false);
-                    } else if (inputFile.getInputStream() != null) {
-                        request.field("photo", new InputStreamBody(inputFile.getInputStream(), inputFile.getFileName()), true);
-                    } else { // assume file is not null (this is existing behaviour as of 1.5.1)
-                        request.field("photo", new FileContainer(inputFile), true);
-                    }
+                    field(request, "photo", inputFile);
 
                     if (photoMessage.getCaption() != null)
                         request.field("caption", photoMessage.getCaption(), "application/json; charset=utf8;");
@@ -288,14 +281,7 @@ public final class TelegramBot {
                             .field("chat_id", chat.getId(), "application/json; charset=utf8;");
 
                     InputFile inputFile = audioMessage.getAudio();
-                    String fileId = inputFile.getFileID();
-                    if (fileId != null) {
-                        request.field("audio", fileId, false);
-                    } else if (inputFile.getInputStream() != null) {
-                        request.field("audio", new InputStreamBody(inputFile.getInputStream(), inputFile.getFileName()), true);
-                    } else { // assume file is not null (this is existing behaviour as of 1.5.1)
-                        request.field("audio", new FileContainer(inputFile), true);
-                    }
+                    field(request, "audio", inputFile);
 
                     Utils.processReplyContent(request, audioMessage);
                     Utils.processNotificationContent(request, audioMessage);
@@ -349,14 +335,7 @@ public final class TelegramBot {
                             .field("chat_id", chat.getId(), "application/json; charset=utf8;");
 
                     InputFile inputFile = documentMessage.getDocument();
-                    String fileId = inputFile.getFileID();
-                    if (fileId != null) {
-                        request.field("document", fileId, false);
-                    } else if (inputFile.getInputStream() != null) {
-                        request.field("document", new InputStreamBody(inputFile.getInputStream(), inputFile.getFileName()), true);
-                    } else { // assume file is not null (this is existing behaviour as of 1.5.1)
-                        request.field("document", new FileContainer(inputFile), true);
-                    }
+                    field(request, "document", inputFile);
 
                     if (documentMessage.getCaption() != null)
                         request.field("caption", documentMessage.getCaption(), "application/json; charset=utf8;");
@@ -404,14 +383,7 @@ public final class TelegramBot {
                             .field("chat_id", chat.getId(), "application/json; charset=utf8;");
 
                     InputFile inputFile = stickerMessage.getSticker();
-                    String fileId = inputFile.getFileID();
-                    if (fileId != null) {
-                        request.field("sticker", fileId, false);
-                    } else if (inputFile.getInputStream() != null) {
-                        request.field("sticker", new InputStreamBody(inputFile.getInputStream(), inputFile.getFileName()), true);
-                    } else { // assume file is not null (this is existing behaviour as of 1.5.1)
-                        request.field("sticker", new FileContainer(inputFile), true);
-                    }
+                    field(request, "sticker", inputFile);
 
                     Utils.processReplyContent(request, stickerMessage);
                     Utils.processNotificationContent(request, stickerMessage);
@@ -449,14 +421,7 @@ public final class TelegramBot {
                             .field("chat_id", chat.getId(), "application/json; charset=utf8;");
 
                     InputFile inputFile = videoMessage.getVideo();
-                    String fileId = inputFile.getFileID();
-                    if (fileId != null) {
-                        request.field("video", fileId, false);
-                    } else if (inputFile.getInputStream() != null) {
-                        request.field("video", new InputStreamBody(inputFile.getInputStream(), inputFile.getFileName()), true);
-                    } else { // assume file is not null (this is existing behaviour as of 1.5.1)
-                        request.field("video", new FileContainer(inputFile), true);
-                    }
+                    field(request, "video", inputFile);
 
                     if (videoMessage.getDuration() > 0) request.field("duration", videoMessage.getDuration());
                     if (videoMessage.getWidth() > 0) request.field("width", videoMessage.getWidth());
@@ -500,14 +465,7 @@ public final class TelegramBot {
                             .field("chat_id", chat.getId(), "application/json; charset=utf8;");
 
                     InputFile inputFile = voiceMessage.getVoice();
-                    String fileId = inputFile.getFileID();
-                    if (fileId != null) {
-                        request.field("voice", fileId, false);
-                    } else if (inputFile.getInputStream() != null) {
-                        request.field("voice", new InputStreamBody(inputFile.getInputStream(), inputFile.getFileName()), true);
-                    } else { // assume file is not null (this is existing behaviour as of 1.5.1)
-                        request.field("voice", new FileContainer(inputFile), true);
-                    }
+                    field(request, "voice", inputFile);
 
                     if (voiceMessage.getDuration() > 0) request.field("duration", voiceMessage.getDuration());
 
@@ -608,6 +566,17 @@ public final class TelegramBot {
         }
 
         return Utils.checkResponseStatus(jsonResponse) ? (messageResponse != null ? messageResponse : MessageImpl.createMessage(jsonResponse, this)) : null;
+    }
+
+    private void field(MultipartBody request, String fieldName, InputFile inputFile) {
+        String fileId = inputFile.getFileID();
+        if (fileId != null) {
+            request.field(fieldName, fileId, false);
+        } else if (inputFile.getInputStream() != null) {
+            request.field(fieldName, new InputStreamBody(inputFile.getInputStream(), inputFile.getFileName()), true);
+        } else { // assume file is not null (this is existing behaviour as of 1.5.1)
+            request.field(fieldName, new FileContainer(inputFile), true);
+        }
     }
 
     private JSONObject editMessageText(String chatId, Long messageId, String inlineMessageId, String text, ParseMode parseMode, boolean disableWebPagePreview, InlineReplyMarkup inlineReplyMarkup) {

--- a/src/main/java/pro/zackpollard/telegrambot/api/TelegramBot.java
+++ b/src/main/java/pro/zackpollard/telegrambot/api/TelegramBot.java
@@ -8,6 +8,7 @@ import com.mashape.unirest.http.exceptions.UnirestException;
 import com.mashape.unirest.request.HttpRequestWithBody;
 import com.mashape.unirest.request.body.MultipartBody;
 import lombok.Getter;
+import org.apache.http.entity.mime.content.InputStreamBody;
 import org.json.JSONObject;
 import pro.zackpollard.telegrambot.api.chat.Chat;
 import pro.zackpollard.telegrambot.api.chat.inline.InlineReplyMarkup;
@@ -222,8 +223,17 @@ public final class TelegramBot {
 
                 try {
                     MultipartBody request = Unirest.post(getBotAPIUrl() + "sendPhoto")
-                            .field("chat_id", chat.getId(), "application/json; charset=utf8;")
-                            .field("photo", photoMessage.getPhoto().getFileID() != null ? photoMessage.getPhoto().getFileID() : new FileContainer(photoMessage.getPhoto()), photoMessage.getPhoto().getFileID() == null);
+                            .field("chat_id", chat.getId(), "application/json; charset=utf8;");
+
+                    InputFile inputFile = photoMessage.getPhoto();
+                    String fileId = inputFile.getFileID();
+                    if (fileId != null) {
+                        request.field("photo", fileId, false);
+                    } else if (inputFile.getInputStream() != null) {
+                        request.field("photo", new InputStreamBody(inputFile.getInputStream(), inputFile.getFileName()), true);
+                    } else { // assume file is not null (this is existing behaviour as of 1.5.1)
+                        request.field("photo", new FileContainer(inputFile), true);
+                    }
 
                     if (photoMessage.getCaption() != null)
                         request.field("caption", photoMessage.getCaption(), "application/json; charset=utf8;");
@@ -275,8 +285,17 @@ public final class TelegramBot {
 
                 try {
                     MultipartBody request = Unirest.post(getBotAPIUrl() + "sendAudio")
-                            .field("chat_id", chat.getId(), "application/json; charset=utf8;")
-                            .field("audio", audioMessage.getAudio().getFileID() != null ? audioMessage.getAudio().getFileID() : new FileContainer(audioMessage.getAudio()), audioMessage.getAudio().getFileID() == null);
+                            .field("chat_id", chat.getId(), "application/json; charset=utf8;");
+
+                    InputFile inputFile = audioMessage.getAudio();
+                    String fileId = inputFile.getFileID();
+                    if (fileId != null) {
+                        request.field("audio", fileId, false);
+                    } else if (inputFile.getInputStream() != null) {
+                        request.field("audio", new InputStreamBody(inputFile.getInputStream(), inputFile.getFileName()), true);
+                    } else { // assume file is not null (this is existing behaviour as of 1.5.1)
+                        request.field("audio", new FileContainer(inputFile), true);
+                    }
 
                     Utils.processReplyContent(request, audioMessage);
                     Utils.processNotificationContent(request, audioMessage);
@@ -327,8 +346,17 @@ public final class TelegramBot {
 
                 try {
                     MultipartBody request = Unirest.post(getBotAPIUrl() + "sendDocument")
-                            .field("chat_id", chat.getId(), "application/json; charset=utf8;")
-                            .field("document", documentMessage.getDocument().getFileID() != null ? documentMessage.getDocument().getFileID() : new FileContainer(documentMessage.getDocument()), documentMessage.getDocument().getFileID() == null);
+                            .field("chat_id", chat.getId(), "application/json; charset=utf8;");
+
+                    InputFile inputFile = documentMessage.getDocument();
+                    String fileId = inputFile.getFileID();
+                    if (fileId != null) {
+                        request.field("document", fileId, false);
+                    } else if (inputFile.getInputStream() != null) {
+                        request.field("document", new InputStreamBody(inputFile.getInputStream(), inputFile.getFileName()), true);
+                    } else { // assume file is not null (this is existing behaviour as of 1.5.1)
+                        request.field("document", new FileContainer(inputFile), true);
+                    }
 
                     if (documentMessage.getCaption() != null)
                         request.field("caption", documentMessage.getCaption(), "application/json; charset=utf8;");
@@ -367,14 +395,23 @@ public final class TelegramBot {
 
                 break;
             }
-            case STICKER:
+            case STICKER: {
 
                 SendableStickerMessage stickerMessage = (SendableStickerMessage) message;
 
                 try {
                     MultipartBody request = Unirest.post(getBotAPIUrl() + "sendSticker")
-                            .field("chat_id", chat.getId(), "application/json; charset=utf8;")
-                            .field("sticker", stickerMessage.getSticker().getFileID() != null ? stickerMessage.getSticker().getFileID() : new FileContainer(stickerMessage.getSticker()), stickerMessage.getSticker().getFileID() == null);
+                            .field("chat_id", chat.getId(), "application/json; charset=utf8;");
+
+                    InputFile inputFile = stickerMessage.getSticker();
+                    String fileId = inputFile.getFileID();
+                    if (fileId != null) {
+                        request.field("sticker", fileId, false);
+                    } else if (inputFile.getInputStream() != null) {
+                        request.field("sticker", new InputStreamBody(inputFile.getInputStream(), inputFile.getFileName()), true);
+                    } else { // assume file is not null (this is existing behaviour as of 1.5.1)
+                        request.field("sticker", new FileContainer(inputFile), true);
+                    }
 
                     Utils.processReplyContent(request, stickerMessage);
                     Utils.processNotificationContent(request, stickerMessage);
@@ -402,15 +439,24 @@ public final class TelegramBot {
                 }
 
                 break;
-
-            case VIDEO:
+            }
+            case VIDEO: {
 
                 SendableVideoMessage videoMessage = (SendableVideoMessage) message;
 
                 try {
                     MultipartBody request = Unirest.post(getBotAPIUrl() + "sendVideo")
-                            .field("chat_id", chat.getId(), "application/json; charset=utf8;")
-                            .field("video", videoMessage.getVideo().getFileID() != null ? videoMessage.getVideo().getFileID() : new FileContainer(videoMessage.getVideo()), videoMessage.getVideo().getFileID() == null);
+                            .field("chat_id", chat.getId(), "application/json; charset=utf8;");
+
+                    InputFile inputFile = videoMessage.getVideo();
+                    String fileId = inputFile.getFileID();
+                    if (fileId != null) {
+                        request.field("video", fileId, false);
+                    } else if (inputFile.getInputStream() != null) {
+                        request.field("video", new InputStreamBody(inputFile.getInputStream(), inputFile.getFileName()), true);
+                    } else { // assume file is not null (this is existing behaviour as of 1.5.1)
+                        request.field("video", new FileContainer(inputFile), true);
+                    }
 
                     if (videoMessage.getDuration() > 0) request.field("duration", videoMessage.getDuration());
                     if (videoMessage.getWidth() > 0) request.field("width", videoMessage.getWidth());
@@ -444,14 +490,24 @@ public final class TelegramBot {
                 }
 
                 break;
-            case VOICE:
+            }
+            case VOICE: {
 
                 SendableVoiceMessage voiceMessage = (SendableVoiceMessage) message;
 
                 try {
                     MultipartBody request = Unirest.post(getBotAPIUrl() + "sendVoice")
-                            .field("chat_id", chat.getId(), "application/json; charset=utf8;")
-                            .field("voice", voiceMessage.getVoice().getFileID() != null ? voiceMessage.getVoice().getFileID() : new FileContainer(voiceMessage.getVoice()), voiceMessage.getVoice().getFileID() == null);
+                            .field("chat_id", chat.getId(), "application/json; charset=utf8;");
+
+                    InputFile inputFile = voiceMessage.getVoice();
+                    String fileId = inputFile.getFileID();
+                    if (fileId != null) {
+                        request.field("voice", fileId, false);
+                    } else if (inputFile.getInputStream() != null) {
+                        request.field("voice", new InputStreamBody(inputFile.getInputStream(), inputFile.getFileName()), true);
+                    } else { // assume file is not null (this is existing behaviour as of 1.5.1)
+                        request.field("voice", new FileContainer(inputFile), true);
+                    }
 
                     if (voiceMessage.getDuration() > 0) request.field("duration", voiceMessage.getDuration());
 
@@ -484,8 +540,8 @@ public final class TelegramBot {
                 }
 
                 break;
-
-            case LOCATION:
+            }
+            case LOCATION: {
 
                 SendableLocationMessage locationMessage = (SendableLocationMessage) message;
 
@@ -505,7 +561,8 @@ public final class TelegramBot {
                 }
 
                 break;
-            case VENUE:
+            }
+            case VENUE: {
 
                 SendableVenueMessage venueMessage = (SendableVenueMessage) message;
 
@@ -518,7 +575,8 @@ public final class TelegramBot {
                             .field("title", venueMessage.getTitle())
                             .field("address", venueMessage.getAddress());
 
-                    if (venueMessage.getFoursquareId() != null) request.field("foursquare_id", venueMessage.getFoursquareId());
+                    if (venueMessage.getFoursquareId() != null)
+                        request.field("foursquare_id", venueMessage.getFoursquareId());
 
                     Utils.processReplyContent(request, venueMessage);
                     Utils.processNotificationContent(request, venueMessage);
@@ -530,7 +588,8 @@ public final class TelegramBot {
                 }
 
                 break;
-            case CHAT_ACTION:
+            }
+            case CHAT_ACTION: {
 
                 SendableChatAction sendableChatAction = (SendableChatAction) message;
 
@@ -545,6 +604,7 @@ public final class TelegramBot {
                 }
 
                 return null;
+            }
         }
 
         return Utils.checkResponseStatus(jsonResponse) ? (messageResponse != null ? messageResponse : MessageImpl.createMessage(jsonResponse, this)) : null;

--- a/src/main/java/pro/zackpollard/telegrambot/api/TelegramBot.java
+++ b/src/main/java/pro/zackpollard/telegrambot/api/TelegramBot.java
@@ -226,7 +226,7 @@ public final class TelegramBot {
                             .field("chat_id", chat.getId(), "application/json; charset=utf8;");
 
                     InputFile inputFile = photoMessage.getPhoto();
-                    Utils.field(request, "photo", inputFile);
+                    Utils.processInputFileField(request, "photo", inputFile);
 
                     if (photoMessage.getCaption() != null)
                         request.field("caption", photoMessage.getCaption(), "application/json; charset=utf8;");
@@ -281,7 +281,7 @@ public final class TelegramBot {
                             .field("chat_id", chat.getId(), "application/json; charset=utf8;");
 
                     InputFile inputFile = audioMessage.getAudio();
-                    Utils.field(request, "audio", inputFile);
+                    Utils.processInputFileField(request, "audio", inputFile);
 
                     Utils.processReplyContent(request, audioMessage);
                     Utils.processNotificationContent(request, audioMessage);
@@ -335,7 +335,7 @@ public final class TelegramBot {
                             .field("chat_id", chat.getId(), "application/json; charset=utf8;");
 
                     InputFile inputFile = documentMessage.getDocument();
-                    Utils.field(request, "document", inputFile);
+                    Utils.processInputFileField(request, "document", inputFile);
 
                     if (documentMessage.getCaption() != null)
                         request.field("caption", documentMessage.getCaption(), "application/json; charset=utf8;");
@@ -383,7 +383,7 @@ public final class TelegramBot {
                             .field("chat_id", chat.getId(), "application/json; charset=utf8;");
 
                     InputFile inputFile = stickerMessage.getSticker();
-                    Utils.field(request, "sticker", inputFile);
+                    Utils.processInputFileField(request, "sticker", inputFile);
 
                     Utils.processReplyContent(request, stickerMessage);
                     Utils.processNotificationContent(request, stickerMessage);
@@ -421,7 +421,7 @@ public final class TelegramBot {
                             .field("chat_id", chat.getId(), "application/json; charset=utf8;");
 
                     InputFile inputFile = videoMessage.getVideo();
-                    Utils.field(request, "video", inputFile);
+                    Utils.processInputFileField(request, "video", inputFile);
 
                     if (videoMessage.getDuration() > 0) request.field("duration", videoMessage.getDuration());
                     if (videoMessage.getWidth() > 0) request.field("width", videoMessage.getWidth());
@@ -465,7 +465,7 @@ public final class TelegramBot {
                             .field("chat_id", chat.getId(), "application/json; charset=utf8;");
 
                     InputFile inputFile = voiceMessage.getVoice();
-                    Utils.field(request, "voice", inputFile);
+                    Utils.processInputFileField(request, "voice", inputFile);
 
                     if (voiceMessage.getDuration() > 0) request.field("duration", voiceMessage.getDuration());
 

--- a/src/main/java/pro/zackpollard/telegrambot/api/chat/message/send/InputFile.java
+++ b/src/main/java/pro/zackpollard/telegrambot/api/chat/message/send/InputFile.java
@@ -29,6 +29,8 @@ public class InputFile {
     private final File file;
     @Getter
     private final String fileName;
+    @Getter
+    private final InputStream inputStream;
 
     /**
      * Create an InputFile object based on an external URL to be sent within a SendableMessage
@@ -65,6 +67,7 @@ public class InputFile {
         this.fileName = FilenameUtils.getBaseName(url.toString()) + "." + extension;
         this.file = file;
         this.fileID = TelegramBot.getFileManager().getFileID(file);
+        this.inputStream = null;
     }
 
     /**
@@ -77,6 +80,7 @@ public class InputFile {
         this.file = file;
         this.fileName = file.getName();
         this.fileID = TelegramBot.getFileManager().getFileID(file);
+        this.inputStream = null;
     }
 
     /**
@@ -90,5 +94,21 @@ public class InputFile {
         this.file = null;
         this.fileName = null;
         this.fileID = fileID;
+        this.inputStream = null;
     }
+
+    /**
+     * Creates an InputFile object based on an InputStream object to be sent within a SendableMessage
+     *
+     * @param inputStream The input stream
+     * @param fileName The file name
+     */
+    public InputFile(InputStream inputStream, String fileName) {
+
+        this.file = null;
+        this.fileID = null;
+        this.fileName = fileName;
+        this.inputStream = inputStream;
+    }
+
 }

--- a/src/main/java/pro/zackpollard/telegrambot/api/menu/InlineMenu.java
+++ b/src/main/java/pro/zackpollard/telegrambot/api/menu/InlineMenu.java
@@ -1,5 +1,6 @@
 package pro.zackpollard.telegrambot.api.menu;
 
+import java.util.Collections;
 import lombok.Getter;
 import lombok.Setter;
 import pro.zackpollard.telegrambot.api.TelegramBot;

--- a/src/main/java/pro/zackpollard/telegrambot/api/utils/Utils.java
+++ b/src/main/java/pro/zackpollard/telegrambot/api/utils/Utils.java
@@ -163,7 +163,7 @@ public class Utils {
      * @param fieldName The name of the field.
      * @param inputFile The input file.
      */
-    public static void field(MultipartBody request, String fieldName, InputFile inputFile) {
+    public static void processInputFileField(MultipartBody request, String fieldName, InputFile inputFile) {
         String fileId = inputFile.getFileID();
         if (fileId != null) {
             request.field(fieldName, fileId, false);

--- a/src/main/java/pro/zackpollard/telegrambot/api/utils/Utils.java
+++ b/src/main/java/pro/zackpollard/telegrambot/api/utils/Utils.java
@@ -2,12 +2,15 @@ package pro.zackpollard.telegrambot.api.utils;
 
 import com.mashape.unirest.http.HttpResponse;
 import com.mashape.unirest.request.body.MultipartBody;
+import org.apache.http.entity.mime.content.InputStreamBody;
 import org.json.JSONException;
 import org.json.JSONObject;
 import pro.zackpollard.telegrambot.api.TelegramBot;
 import pro.zackpollard.telegrambot.api.chat.message.ForceReply;
+import pro.zackpollard.telegrambot.api.chat.message.send.InputFile;
 import pro.zackpollard.telegrambot.api.chat.message.send.NotificationOptions;
 import pro.zackpollard.telegrambot.api.chat.message.send.ReplyingOptions;
+import pro.zackpollard.telegrambot.api.internal.chat.message.send.FileContainer;
 import pro.zackpollard.telegrambot.api.keyboards.InlineKeyboardMarkup;
 import pro.zackpollard.telegrambot.api.keyboards.ReplyKeyboardHide;
 import pro.zackpollard.telegrambot.api.keyboards.ReplyKeyboardMarkup;
@@ -151,6 +154,24 @@ public class Utils {
         }
 
         return false;
+    }
+
+    /**
+     * Adds an input file to a request, with the given field name.
+     *
+     * @param request The request to be added to.
+     * @param fieldName The name of the field.
+     * @param inputFile The input file.
+     */
+    public static void field(MultipartBody request, String fieldName, InputFile inputFile) {
+        String fileId = inputFile.getFileID();
+        if (fileId != null) {
+            request.field(fieldName, fileId, false);
+        } else if (inputFile.getInputStream() != null) {
+            request.field(fieldName, new InputStreamBody(inputFile.getInputStream(), inputFile.getFileName()), true);
+        } else { // assume file is not null (this is existing behaviour as of 1.5.1)
+            request.field(fieldName, new FileContainer(inputFile), true);
+        }
     }
 
     /**


### PR DESCRIPTION
This is a non-API-breaking change so can be committed for a 1.x.0 versioning cycle!

I've tested it and it works.

Telegram bot: @graphibot, may or may not be online, idk.
I can bring it online when I am if proof is needed!