### PR TITLE
Comment out nocomment option, so javadoc contains comments et all

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -114,7 +114,7 @@
                     <quiet>true</quiet>
                     <nonavbar>true</nonavbar>
                     <notree>true</notree>
-                    <nocomment>true</nocomment>
+                    <!--nocomment>true</nocomment-->
                     <nohelp>true</nohelp>
                 </configuration>
                 <executions>


### PR DESCRIPTION
Fix Zack's copypasta derp, so javadocs actually contain comments