### PR TITLE
Variety of improvements to Menu API

### DIFF
--- a/menus/src/main/java/pro/zackpollard/telegrambot/api/menu/InlineMenu.java
+++ b/menus/src/main/java/pro/zackpollard/telegrambot/api/menu/InlineMenu.java
@@ -27,9 +27,13 @@ public class InlineMenu {
     private int internalId;
     @Getter
     Message baseMessage;
+    @Deprecated
     @Getter
     @Setter
     private InlineMenu parent;
+    @Getter
+    @Setter
+    private InlineMenu lastMenu;
     Predicate<User> userPredicate;
     List<InlineMenuRow> rows;
 
@@ -153,7 +157,7 @@ public class InlineMenu {
     }
 
     /**
-     * Apply any updates to the message
+     * Apply any updates to the message (for viewer on Telegram)
      */
     public void apply() {
         baseMessage.getBotInstance().editMessageReplyMarkup(baseMessage, toKeyboard());

--- a/menus/src/main/java/pro/zackpollard/telegrambot/api/menu/InlineMenuRowBuilder.java
+++ b/menus/src/main/java/pro/zackpollard/telegrambot/api/menu/InlineMenuRowBuilder.java
@@ -1,10 +1,7 @@
 package pro.zackpollard.telegrambot.api.menu;
 
 import pro.zackpollard.telegrambot.api.menu.button.InlineMenuButton;
-import pro.zackpollard.telegrambot.api.menu.button.builder.BackButtonBuilder;
-import pro.zackpollard.telegrambot.api.menu.button.builder.SubInlineMenuButtonBuilder;
-import pro.zackpollard.telegrambot.api.menu.button.builder.ToggleInlineMenuButtonBuilder;
-import pro.zackpollard.telegrambot.api.menu.button.builder.UserInputInlineMenuButtonBuilder;
+import pro.zackpollard.telegrambot.api.menu.button.builder.*;
 
 import java.util.List;
 
@@ -93,6 +90,7 @@ public class InlineMenuRowBuilder<T extends AbstractInlineMenuBuilder> {
     /**
      * Creates a new back button builder.
      * @return a new back button builder
+     * @see pro.zackpollard.telegrambot.api.menu.button.impl.BackButton
      */
     public BackButtonBuilder<T> backButton() {
         if (!(parent instanceof SubInlineMenuBuilder)) {
@@ -106,13 +104,29 @@ public class InlineMenuRowBuilder<T extends AbstractInlineMenuBuilder> {
      * Creates a new back button builder with provided text
      * @param text Text for the button to initialize with
      * @return a new back button builder
+     * @see pro.zackpollard.telegrambot.api.menu.button.impl.BackButton
      */
     public BackButtonBuilder<T> backButton(String text) {
-        if (!(parent instanceof SubInlineMenuBuilder)) {
-            throw new UnsupportedOperationException("Back buttons are only allowed for sub menus!");
-        }
-
         return new BackButtonBuilder<>(this, text);
+    }
+
+    /**
+     * Creates a new dummy button builder with provided text
+     * @param text Text for the button to initialize with
+     * @return a new dummy button builder
+     * @see pro.zackpollard.telegrambot.api.menu.button.impl.DummyButton
+     */
+    public DummyButtonBuilder<T> dummyButton(String text) {
+        return new DummyButtonBuilder<>(this, text);
+    }
+
+    /**
+     * Creates a new dummy button builder
+     * @return a new dummy button builder
+     * @see pro.zackpollard.telegrambot.api.menu.button.impl.DummyButton
+     */
+    public DummyButtonBuilder<T> dummyButton() {
+        return new DummyButtonBuilder<>(this);
     }
 
     /**

--- a/menus/src/main/java/pro/zackpollard/telegrambot/api/menu/button/builder/DummyButtonBuilder.java
+++ b/menus/src/main/java/pro/zackpollard/telegrambot/api/menu/button/builder/DummyButtonBuilder.java
@@ -1,0 +1,55 @@
+package pro.zackpollard.telegrambot.api.menu.button.builder;
+
+import pro.zackpollard.telegrambot.api.chat.CallbackQuery;
+import pro.zackpollard.telegrambot.api.menu.AbstractInlineMenuBuilder;
+import pro.zackpollard.telegrambot.api.menu.InlineMenuRowBuilder;
+import pro.zackpollard.telegrambot.api.menu.button.AbstractButtonBuilder;
+import pro.zackpollard.telegrambot.api.menu.button.InlineMenuButton;
+import pro.zackpollard.telegrambot.api.menu.button.impl.DummyButton;
+import pro.zackpollard.telegrambot.api.utils.Utils;
+
+import java.util.function.BiConsumer;
+
+/**
+ * The builder for a button which once pressed, executes a callback where
+ * the developer can do whatever they want.
+ *
+ * @author Mazen Kotb
+ */
+public class DummyButtonBuilder<T extends AbstractInlineMenuBuilder>
+        extends AbstractButtonBuilder<DummyButtonBuilder<T>, T> {
+    private BiConsumer<DummyButton, CallbackQuery> callback;
+
+    public DummyButtonBuilder(InlineMenuRowBuilder<T> parent) {
+        super(parent);
+    }
+
+    public DummyButtonBuilder(InlineMenuRowBuilder<T> parent, String text) {
+        super(parent, text);
+    }
+
+    /**
+     * Required. A callback to execute once the button is pressed.
+     */
+    public DummyButtonBuilder<T> callback(BiConsumer<DummyButton, CallbackQuery> cb) {
+        this.callback = cb;
+        return this;
+    }
+
+    @Override
+    protected DummyButtonBuilder<T> instance() {
+        return this;
+    }
+
+    @Override
+    public InlineMenuRowBuilder<T> build() {
+        Utils.validateNotNull(text, callback);
+        parent.internalAddButton(buildButton());
+        return parent;
+    }
+
+    @Override
+    public InlineMenuButton buildButton() {
+        return new DummyButton(null, parent.rowIndex(), text, callback);
+    }
+}

--- a/menus/src/main/java/pro/zackpollard/telegrambot/api/menu/button/builder/SubInlineMenuButtonBuilder.java
+++ b/menus/src/main/java/pro/zackpollard/telegrambot/api/menu/button/builder/SubInlineMenuButtonBuilder.java
@@ -8,6 +8,8 @@ import pro.zackpollard.telegrambot.api.menu.button.InlineMenuButton;
 import pro.zackpollard.telegrambot.api.menu.button.impl.SubInlineMenuButton;
 import pro.zackpollard.telegrambot.api.utils.Utils;
 
+import java.util.function.Supplier;
+
 /**
  * Builder for SubMenus
  * @param <T> menu builder type
@@ -16,7 +18,7 @@ import pro.zackpollard.telegrambot.api.utils.Utils;
  */
 public class SubInlineMenuButtonBuilder<T extends AbstractInlineMenuBuilder>
         extends AbstractButtonBuilder<SubInlineMenuButtonBuilder<T>, T> {
-    private InlineMenu nextMenu;
+    private Supplier<InlineMenu> nextMenu;
 
     public SubInlineMenuButtonBuilder(InlineMenuRowBuilder<T> parent) {
         super(parent);
@@ -42,11 +44,22 @@ public class SubInlineMenuButtonBuilder<T extends AbstractInlineMenuBuilder>
     }
 
     /**
-     * Required. Set the nextMenu field.
+     * Set the nextMenu field.
      * @param menu menu which will open when the button is pressed
      * @return this
      */
     public SubInlineMenuButtonBuilder<T> nextMenu(InlineMenu menu) {
+        this.nextMenu = () -> menu;
+        return this;
+    }
+
+    /**
+     * Set the nextMenu supplier. This will be called *every* time the button
+     * is pressed to generate a menu.
+     *
+     * @return this
+     */
+    public SubInlineMenuButtonBuilder<T> nextMenu(Supplier<InlineMenu> menu) {
         this.nextMenu = menu;
         return this;
     }

--- a/menus/src/main/java/pro/zackpollard/telegrambot/api/menu/button/impl/BackButton.java
+++ b/menus/src/main/java/pro/zackpollard/telegrambot/api/menu/button/impl/BackButton.java
@@ -9,7 +9,18 @@ import pro.zackpollard.telegrambot.api.menu.button.builder.BackButtonBuilder;
 
 /**
  * A button which once pressed will exit it's current menu
- * and as a result open it's parent's.
+ * and as a result open the last seen menu.
+ *
+ * NOTE: Given a menu scenario like this:
+ *
+ * Menu 1 <-> Menu 2 <-> Menu 3
+ *
+ * If the user goes from 1->2->3 then hits the back button
+ * on 3, it will take them back to 2. If they hit the back
+ * button on 2, it will return them to menu 1. This is to
+ * best follow their menu history and not send them to menu
+ * 3 when they hit the back button on menu 2 after they've
+ * been to menu 3. (what a sentence)
  *
  * @author Mazen Kotb
  */
@@ -46,7 +57,7 @@ public class BackButton extends AbstractInlineMenuButton {
     }
 
     /**
-     * If there is a valid parent, execute callback, unregister the current menu, and start the parent.
+     * If there is a last menu, execute callback, unregister the current menu, and start the parent.
      *
      * @param query Query to process, unused.
      * @see InlineMenu#unregister()
@@ -54,12 +65,12 @@ public class BackButton extends AbstractInlineMenuButton {
      */
     @Override
     public void handlePress(CallbackQuery query) {
-        InlineMenu parent = owner.getParent();
+        InlineMenu lastMenu = owner.getLastMenu();
 
-        if (parent != null) {
+        if (lastMenu != null) {
             executeCallback();
             owner.unregister();
-            parent.start();
+            lastMenu.start();
         }
     }
 }

--- a/menus/src/main/java/pro/zackpollard/telegrambot/api/menu/button/impl/DummyButton.java
+++ b/menus/src/main/java/pro/zackpollard/telegrambot/api/menu/button/impl/DummyButton.java
@@ -1,0 +1,39 @@
+package pro.zackpollard.telegrambot.api.menu.button.impl;
+
+import pro.zackpollard.telegrambot.api.chat.CallbackQuery;
+import pro.zackpollard.telegrambot.api.keyboards.InlineKeyboardButton;
+import pro.zackpollard.telegrambot.api.menu.InlineMenu;
+import pro.zackpollard.telegrambot.api.menu.button.AbstractInlineMenuButton;
+
+import java.util.function.BiConsumer;
+
+/**
+ * A button which once pressed, executes a callback where
+ * the developer can do whatever they want.
+ *
+ * @author Mazen Kotb
+ */
+public class DummyButton extends AbstractInlineMenuButton {
+    private BiConsumer<DummyButton, CallbackQuery> callback;
+
+    public DummyButton(InlineMenu owner, int row, BiConsumer<DummyButton, CallbackQuery> callback) {
+        super(owner, row);
+        this.callback = callback;
+    }
+
+    public DummyButton(InlineMenu owner, int row, String text, BiConsumer<DummyButton, CallbackQuery> callback) {
+        super(owner, row, text);
+        this.callback = callback;
+    }
+
+    @Override
+    public InlineKeyboardButton toKeyboardButton() {
+        return keyboardBuilder().build();
+    }
+
+    @Override
+    public void handlePress(CallbackQuery query) {
+        executeCallback();
+        callback.accept(this, query);
+    }
+}

--- a/menus/src/main/java/pro/zackpollard/telegrambot/api/menu/button/impl/SubInlineMenuButton.java
+++ b/menus/src/main/java/pro/zackpollard/telegrambot/api/menu/button/impl/SubInlineMenuButton.java
@@ -7,36 +7,37 @@ import pro.zackpollard.telegrambot.api.menu.InlineMenuBuilder;
 import pro.zackpollard.telegrambot.api.menu.button.AbstractInlineMenuButton;
 import pro.zackpollard.telegrambot.api.menu.button.builder.SubInlineMenuButtonBuilder;
 
+import java.util.function.Supplier;
+
 /**
  * A button which opens a sub menu.
  *
  * @author Mazen Kotb
  */
 public class SubInlineMenuButton extends AbstractInlineMenuButton {
-    private final InlineMenu nextMenu;
+    private final Supplier<InlineMenu> nextMenu;
 
     @Deprecated
-    public SubInlineMenuButton(InlineMenu owner, int row, int num, InlineMenu nextMenu) {
-        super(owner, row, num);
-        this.nextMenu = nextMenu;
-    }
-
-    @Deprecated
-    public SubInlineMenuButton(InlineMenu owner, int row, int num, InlineMenu nextMenu, String text) {
-        super(owner, row, num, text);
-        this.nextMenu = nextMenu;
-    }
-
     public SubInlineMenuButton(InlineMenu owner, int row, InlineMenu nextMenu) {
+        super(owner, row);
+        this.nextMenu = () -> nextMenu;
+    }
+
+    @Deprecated
+    public SubInlineMenuButton(InlineMenu owner, int row, InlineMenu nextMenu, String text) {
+        super(owner, row, text);
+        this.nextMenu = () -> nextMenu;
+    }
+
+    public SubInlineMenuButton(InlineMenu owner, int row, Supplier<InlineMenu> nextMenu) {
         super(owner, row);
         this.nextMenu = nextMenu;
     }
 
-    public SubInlineMenuButton(InlineMenu owner, int row, InlineMenu nextMenu, String text) {
+    public SubInlineMenuButton(InlineMenu owner, int row, Supplier<InlineMenu> nextMenu, String text) {
         super(owner, row, text);
         this.nextMenu = nextMenu;
     }
-
 
     public static SubInlineMenuButtonBuilder builder() {
         return new SubInlineMenuButtonBuilder<InlineMenuBuilder>(null);
@@ -55,6 +56,9 @@ public class SubInlineMenuButton extends AbstractInlineMenuButton {
     public void handlePress(CallbackQuery query) {
         executeCallback();
         owner.unregister();
-        nextMenu.start();
+        InlineMenu menu = nextMenu.get();
+
+        menu.setLastMenu(owner);
+        menu.start();
     }
 }

--- a/menus/src/main/java/pro/zackpollard/telegrambot/api/menu/button/impl/ToggleInlineMenuButton.java
+++ b/menus/src/main/java/pro/zackpollard/telegrambot/api/menu/button/impl/ToggleInlineMenuButton.java
@@ -89,6 +89,7 @@ public class ToggleInlineMenuButton extends AbstractInlineMenuButton {
     @Override
     public void handlePress(CallbackQuery query) {
         value = !value;
+        executeCallback();
         setText(callback.handleToggle(this, value));
     }
 }

--- a/menus/src/main/java/pro/zackpollard/telegrambot/api/menu/internal/InlineMenuRegistryImpl.java
+++ b/menus/src/main/java/pro/zackpollard/telegrambot/api/menu/internal/InlineMenuRegistryImpl.java
@@ -40,18 +40,15 @@ public class InlineMenuRegistryImpl implements InlineMenuRegistry {
 
     @Override
     public void register(InlineMenu menu) {
-        int next = nextId.get();
+        int next = nextId.getAndIncrement();
 
         menus.put(next, menu);
         menu.setInternalId(next);
-
-        updateNextId();
     }
 
     @Override
     public void unregister(InlineMenu menu) {
         menus.remove(menu.getInternalId());
-        updateNextId();
     }
 
     private boolean process(CallbackQuery query) {
@@ -67,17 +64,5 @@ public class InlineMenuRegistryImpl implements InlineMenuRegistry {
         return menu != null &&
                 menu.handle(query, Integer.parseInt(matcher.group(2)),
                         Integer.parseInt(matcher.group(3)));
-    }
-
-    private void updateNextId() {
-        int selectedId = -1;
-        Set<Integer> usedIds = menus.keySet();
-
-        for (int i = 0; selectedId == -1; i++) {
-            if (!usedIds.contains(i))
-                selectedId = i;
-        }
-
-        nextId.set(selectedId);
     }
 }


### PR DESCRIPTION
- [x] Add dummy button: Allows developers to execute whatever code they want for that button, it does nothing otherwise
- [x] Remove opening slot ids for menu callbacks to avoid bugs with id conflicts
- [x] Make back button refer to the last seen menu instead of "root menu"
- [x] Add extensibility to inline menu buttons with lazy creation
- [x] Execute buttonCallbacks on toggle buttons